### PR TITLE
Elevator direction priorities & Networking module rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ See test README for test file structure.
 [ElevatorSubsystem](#elevatorsubsystem)<br>
 [FloorSubsystem](#floorsubsystem)<br>
 [SchedulerSubsystem](#schedulersubsystem)<br>
-[Networking](#networking)<br>
+[Messaging](#networking)<br>
 [Tests](#tests)<br>
 [UML](#uml)<br>
 
@@ -89,7 +89,7 @@ See test README for test file structure.
 - Sends DestinationEvent records to the Elevator
 - Sends ElevatorStateEvent records to the Floor
 
-### Networking
+### Messaging
 
 #### <u>Events</u>
 
@@ -146,7 +146,7 @@ See test README for test file structure.
 **ParserTest.java**
 - Tests parser class
 
-<u>Networking</u>
+<u>Messaging</u>
 **DMA_ReceiverTest.java**
 - Tests DMA_Receiver class
 

--- a/src/ElevatorSubsytem/Elevator.java
+++ b/src/ElevatorSubsytem/Elevator.java
@@ -6,10 +6,14 @@
 
 package ElevatorSubsytem;
 
-import Networking.Direction;
-import Networking.Messages.*;
-import Networking.Receivers.DMA_Receiver;
-import Networking.Transmitters.DMA_Transmitter;
+import Messaging.Commands.MoveElevatorCommand;
+import Messaging.Commands.MovePassengersCommand;
+import Messaging.Direction;
+import Messaging.Events.DestinationEvent;
+import Messaging.Events.ElevatorStateEvent;
+import Messaging.Receivers.DMA_Receiver;
+import Messaging.SystemMessage;
+import Messaging.Transmitters.DMA_Transmitter;
 import com.sun.jdi.InvalidTypeException;
 import Configuration.Configurator;
 import Configuration.Config;

--- a/src/FloorSubsystem/DestinationDispatcher.java
+++ b/src/FloorSubsystem/DestinationDispatcher.java
@@ -9,9 +9,9 @@
 
 package FloorSubsystem;
 
-import Networking.Messages.DestinationEvent;
-import Networking.Messages.FloorInputEvent;
-import Networking.Transmitters.DMA_Transmitter;
+import Messaging.Events.DestinationEvent;
+import Messaging.Events.FloorInputEvent;
+import Messaging.Transmitters.DMA_Transmitter;
 
 import java.util.ArrayList;
 import java.util.Comparator;

--- a/src/FloorSubsystem/Floor.java
+++ b/src/FloorSubsystem/Floor.java
@@ -6,9 +6,13 @@
 
 package FloorSubsystem;
 
-import Networking.Direction;
-import Networking.Messages.*;
-import Networking.Receivers.DMA_Receiver;
+import Messaging.Commands.SendPassengersCommand;
+import Messaging.Direction;
+import Messaging.Events.DestinationEvent;
+import Messaging.Events.ElevatorStateEvent;
+import Messaging.Events.PassengerLoadEvent;
+import Messaging.Receivers.DMA_Receiver;
+import Messaging.SystemMessage;
 import com.sun.jdi.InvalidTypeException;
 
 import java.util.ArrayList;

--- a/src/FloorSubsystem/Parser.java
+++ b/src/FloorSubsystem/Parser.java
@@ -44,8 +44,8 @@
 
 package FloorSubsystem;
 
-import Networking.Direction;
-import Networking.Messages.FloorInputEvent;
+import Messaging.Direction;
+import Messaging.Events.FloorInputEvent;
 
 import java.io.*;
 import java.util.*;

--- a/src/Main.java
+++ b/src/Main.java
@@ -4,9 +4,9 @@ import ElevatorSubsytem.Elevator;
 import FloorSubsystem.DestinationDispatcher;
 import FloorSubsystem.Floor;
 import FloorSubsystem.Parser;
-import Networking.Messages.FloorInputEvent;
-import Networking.Receivers.DMA_Receiver;
-import Networking.Transmitters.DMA_Transmitter;
+import Messaging.Events.FloorInputEvent;
+import Messaging.Receivers.DMA_Receiver;
+import Messaging.Transmitters.DMA_Transmitter;
 import SchedulerSubsystem.Scheduler;
 
 import java.util.ArrayList;

--- a/src/Messaging/Commands/MoveElevatorCommand.java
+++ b/src/Messaging/Commands/MoveElevatorCommand.java
@@ -1,6 +1,6 @@
-package Networking.Messages;
+package Messaging.Commands;
 
-import Networking.Direction;
+import Messaging.Direction;
 
 /**
  * MoveElevatorCommand Record, Command to elevator to move until the next floor is reached.

--- a/src/Messaging/Commands/MovePassengersCommand.java
+++ b/src/Messaging/Commands/MovePassengersCommand.java
@@ -1,4 +1,6 @@
-package Networking.Messages;
+package Messaging.Commands;
+
+import Messaging.Events.DestinationEvent;
 
 import java.util.ArrayList;
 

--- a/src/Messaging/Commands/PassengerArrivedCommand.java
+++ b/src/Messaging/Commands/PassengerArrivedCommand.java
@@ -1,0 +1,22 @@
+package Messaging.Commands;
+
+import Messaging.Events.DestinationEvent;
+
+/**
+ * TODO: Docs
+ *
+ * @author Alexandre Marques
+ * @version Iteration-2
+ */
+public record PassengerArrivedCommand(int floorNum, DestinationEvent passenger) implements SystemCommand {
+    /**
+     * Match floor number with the given key.
+     *
+     * @param key The floor number of the floor trying to process this event.
+     * @return True if the floor has the appropriate key, indicating this message is addressed to it.
+     */
+    @Override
+    public boolean matchKey(int key) {
+        return key == floorNum;
+    }
+}

--- a/src/Messaging/Commands/SendPassengersCommand.java
+++ b/src/Messaging/Commands/SendPassengersCommand.java
@@ -1,7 +1,7 @@
-package Networking.Messages;
+package Messaging.Commands;
 
-import Networking.Direction;
-import Networking.Transmitters.DMA_Transmitter;
+import Messaging.Direction;
+import Messaging.Transmitters.DMA_Transmitter;
 
 /**
  * SendPassengersCommand Record, Command to floor to send passengers back through the provided transmitter.

--- a/src/Messaging/Commands/SystemCommand.java
+++ b/src/Messaging/Commands/SystemCommand.java
@@ -1,4 +1,6 @@
-package Networking.Messages;
+package Messaging.Commands;
+
+import Messaging.SystemMessage;
 
 /**
  * Interface definition for all commands passed in the system to inherit.

--- a/src/Messaging/Direction.java
+++ b/src/Messaging/Direction.java
@@ -4,7 +4,7 @@
  * @version 20240202
  */
 
-package Networking;
+package Messaging;
 
 public enum Direction {
     UP,

--- a/src/Messaging/Direction.java
+++ b/src/Messaging/Direction.java
@@ -7,7 +7,16 @@
 package Messaging;
 
 public enum Direction {
-    UP,
-    DOWN,
-    STOPPED // TODO: Remove (Deprecated)
+    UP(1),
+    DOWN(-1);
+
+    private final int displacement;
+
+    Direction(int displacement) {
+        this.displacement = displacement;
+    }
+
+    public int getDisplacement() {
+        return displacement;
+    }
 }

--- a/src/Messaging/Events/DestinationEvent.java
+++ b/src/Messaging/Events/DestinationEvent.java
@@ -1,6 +1,6 @@
-package Networking.Messages;
+package Messaging.Events;
 
-import Networking.Direction;
+import Messaging.Direction;
 /**
  * DestinationEvent record, holds data modelling a destination.
  * Floor requests, and passengers in the system can both be modeled as a destination to be served.

--- a/src/Messaging/Events/ElevatorStateEvent.java
+++ b/src/Messaging/Events/ElevatorStateEvent.java
@@ -1,6 +1,6 @@
-package Networking.Messages;
+package Messaging.Events;
 
-import Networking.Direction;
+import Messaging.Direction;
 
 import java.util.HashMap;
 

--- a/src/Messaging/Events/ElevatorStateEvent.java
+++ b/src/Messaging/Events/ElevatorStateEvent.java
@@ -1,7 +1,5 @@
 package Messaging.Events;
 
-import Messaging.Direction;
-
 import java.util.HashMap;
 
 /**
@@ -10,8 +8,6 @@ import java.util.HashMap;
  *
  * @param elevatorNum The elevator number identifying the elevator
  * @param currentFloor Floor that the elevator is at.
- * @param direction The direction a passenger would like to go (UP/DOWN/STOPPED).
- *                  DEPRECATED: Likely to remove if not needed by end of iteration 2 (passengerCountMap can replace)
  * @param passengerCountMap Map passengers (Destination Events) to the count of identical passengers in the elevator.
  *                          Can derive destination set, and total passenger count of the elevator from this.
  *
@@ -19,6 +15,5 @@ import java.util.HashMap;
  * @version Iteration-2
  */
 public record ElevatorStateEvent
-        (int elevatorNum, int currentFloor, @Deprecated Direction direction,
-         HashMap<DestinationEvent, Integer> passengerCountMap)
+        (int elevatorNum, int currentFloor, HashMap<DestinationEvent, Integer> passengerCountMap)
         implements SystemEvent {}

--- a/src/Messaging/Events/FloorInputEvent.java
+++ b/src/Messaging/Events/FloorInputEvent.java
@@ -1,6 +1,6 @@
-package Networking.Messages;
+package Messaging.Events;
 
-import Networking.Direction;
+import Messaging.Direction;
 
 /**
  * FloorInputEvent record, models an input event to the system. These events

--- a/src/Messaging/Events/FloorRequestEvent.java
+++ b/src/Messaging/Events/FloorRequestEvent.java
@@ -1,0 +1,13 @@
+package Messaging.Events;
+
+
+/**
+ * TODO: docs
+ *
+ * @author Alexandre Marques
+ * @version iteration-2
+ */
+public record FloorRequestEvent
+        (DestinationEvent destinationEvent, long time)
+        implements SystemEvent {
+}

--- a/src/Messaging/Events/PassengerLoadEvent.java
+++ b/src/Messaging/Events/PassengerLoadEvent.java
@@ -1,4 +1,4 @@
-package Networking.Messages;
+package Messaging.Events;
 
 import java.util.ArrayList;
 

--- a/src/Messaging/Events/SystemEvent.java
+++ b/src/Messaging/Events/SystemEvent.java
@@ -1,4 +1,6 @@
-package Networking.Messages;
+package Messaging.Events;
+
+import Messaging.SystemMessage;
 
 /**
  * Interface definition for all events passed in the system to inherit.

--- a/src/Messaging/Receivers/DMA_Receiver.java
+++ b/src/Messaging/Receivers/DMA_Receiver.java
@@ -6,10 +6,10 @@
  * @author Alexandre Marques
  * @version Iteration-1
  */
-package Networking.Receivers;
+package Messaging.Receivers;
 
-import Networking.Messages.SystemCommand;
-import Networking.Messages.SystemMessage;
+import Messaging.Commands.SystemCommand;
+import Messaging.SystemMessage;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/Messaging/Receivers/Receiver.java
+++ b/src/Messaging/Receivers/Receiver.java
@@ -4,9 +4,9 @@
  * @author Alexandre Marques
  * @version Iteration-1
  */
-package Networking.Receivers;
+package Messaging.Receivers;
 
-import Networking.Messages.SystemMessage;
+import Messaging.SystemMessage;
 
 public interface Receiver {
     /**

--- a/src/Messaging/SystemMessage.java
+++ b/src/Messaging/SystemMessage.java
@@ -1,4 +1,4 @@
-package Networking.Messages;
+package Messaging;
 
 /**
  * Interface definition for all messages passed in the system to inherit.

--- a/src/Messaging/Transmitters/DMA_Transmitter.java
+++ b/src/Messaging/Transmitters/DMA_Transmitter.java
@@ -6,10 +6,10 @@
  * @author Alexandre Marques
  * @version Iteration-1
  */
-package Networking.Transmitters;
+package Messaging.Transmitters;
 
-import Networking.Messages.SystemMessage;
-import Networking.Receivers.DMA_Receiver;
+import Messaging.SystemMessage;
+import Messaging.Receivers.DMA_Receiver;
 
 import java.util.ArrayList;
 

--- a/src/Messaging/Transmitters/Transmitter.java
+++ b/src/Messaging/Transmitters/Transmitter.java
@@ -5,9 +5,9 @@
  * @version Iteration-1
  */
 
-package Networking.Transmitters;
+package Messaging.Transmitters;
 
-import Networking.Messages.SystemMessage;
+import Messaging.SystemMessage;
 
 public interface Transmitter {
     /**

--- a/src/SchedulerSubsystem/Loader.java
+++ b/src/SchedulerSubsystem/Loader.java
@@ -1,8 +1,12 @@
 package SchedulerSubsystem;
 
-import Networking.Messages.*;
-import Networking.Receivers.DMA_Receiver;
-import Networking.Transmitters.DMA_Transmitter;
+import Messaging.Commands.MovePassengersCommand;
+import Messaging.Commands.SendPassengersCommand;
+import Messaging.Events.DestinationEvent;
+import Messaging.Events.ElevatorStateEvent;
+import Messaging.Events.PassengerLoadEvent;
+import Messaging.Receivers.DMA_Receiver;
+import Messaging.Transmitters.DMA_Transmitter;
 
 import java.util.ArrayList;
 

--- a/src/SchedulerSubsystem/Scheduler.java
+++ b/src/SchedulerSubsystem/Scheduler.java
@@ -1,12 +1,12 @@
 package SchedulerSubsystem;
 
-import Networking.Direction;
-import Networking.Messages.DestinationEvent;
-import Networking.Messages.ElevatorStateEvent;
-import Networking.Messages.MoveElevatorCommand;
-import Networking.Messages.SystemMessage;
-import Networking.Receivers.DMA_Receiver;
-import Networking.Transmitters.DMA_Transmitter;
+import Messaging.Direction;
+import Messaging.Events.DestinationEvent;
+import Messaging.Events.ElevatorStateEvent;
+import Messaging.Commands.MoveElevatorCommand;
+import Messaging.SystemMessage;
+import Messaging.Receivers.DMA_Receiver;
+import Messaging.Transmitters.DMA_Transmitter;
 import com.sun.jdi.InvalidTypeException;
 import org.junit.jupiter.api.*;
 

--- a/src/SchedulerSubsystem/Scheduler.java
+++ b/src/SchedulerSubsystem/Scheduler.java
@@ -43,7 +43,9 @@ public class Scheduler implements Runnable {
      */
     private void storeFloorRequest(FloorRequestEvent event) {
         // Store event locally to use in scheduling
-        floorRequestsToTime.put(event.destinationEvent(), event.time());
+        if (!floorRequestsToTime.containsKey(event.destinationEvent()))
+            // Only store request if it does not already exist
+            floorRequestsToTime.put(event.destinationEvent(), event.time());
     }
 
     /**
@@ -104,12 +106,12 @@ public class Scheduler implements Runnable {
      */
     private Direction getOldestFloorDirFromElevator(int currentFloor) {
         if (floorRequestsToTime.isEmpty()) return null;
-        Long waitTime = (long) -1;
+        Long waitTime = Long.MAX_VALUE;
         int sourceFloor = -1;
-        for (Map.Entry<DestinationEvent, Long> x : floorRequestsToTime.entrySet()) {
-            if (x.getValue() > waitTime) {
-                waitTime = x.getValue();
-                sourceFloor = x.getKey().destinationFloor();
+        for (Map.Entry<DestinationEvent, Long> request : floorRequestsToTime.entrySet()) {
+            if (request.getValue() < waitTime) {
+                waitTime = request.getValue();
+                sourceFloor = request.getKey().destinationFloor();
             }
         }
         return (sourceFloor > currentFloor) ? Direction.UP : Direction.DOWN;

--- a/test/unit/FloorSubsystem/ParserTest.java
+++ b/test/unit/FloorSubsystem/ParserTest.java
@@ -7,8 +7,8 @@
 package unit.FloorSubsystem;
 
 import FloorSubsystem.Parser;
-import Networking.Direction;
-import Networking.Messages.FloorInputEvent;
+import Messaging.Direction;
+import Messaging.Events.FloorInputEvent;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;

--- a/test/unit/Networking/DMA_ReceiverTest.java
+++ b/test/unit/Networking/DMA_ReceiverTest.java
@@ -1,9 +1,10 @@
 package unit.Networking;
 
-import Networking.Direction;
-import Networking.Messages.DestinationEvent;
-import Networking.Messages.SystemEvent;
-import Networking.Receivers.DMA_Receiver;
+import Messaging.Direction;
+import Messaging.Events.DestinationEvent;
+import Messaging.Events.SystemEvent;
+import Messaging.Receivers.DMA_Receiver;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -12,13 +13,12 @@ class DMA_ReceiverTest {
 
     DMA_Receiver receiver;
     SystemEvent systemEvent;
-    @Test
+    @BeforeEach
     void setUp() {
         this.receiver = new DMA_Receiver();
     }
     @Test
     void setAndReceiveMessage() {
-        setUp();
         systemEvent = new DestinationEvent(2, Direction.UP);
         receiver.setMessage(systemEvent);
         DestinationEvent event = (DestinationEvent) receiver.receive();

--- a/test/unit/Networking/DMA_TransmitterTest.java
+++ b/test/unit/Networking/DMA_TransmitterTest.java
@@ -1,10 +1,11 @@
 package unit.Networking;
 
-import Networking.Direction;
-import Networking.Messages.DestinationEvent;
-import Networking.Messages.SystemEvent;
-import Networking.Receivers.DMA_Receiver;
-import Networking.Transmitters.DMA_Transmitter;
+import Messaging.Direction;
+import Messaging.Events.DestinationEvent;
+import Messaging.Events.SystemEvent;
+import Messaging.Receivers.DMA_Receiver;
+import Messaging.Transmitters.DMA_Transmitter;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -15,7 +16,7 @@ class DMA_TransmitterTest {
     private DMA_Transmitter transmitter;
     SystemEvent systemEvent;
 
-    @Test
+    @BeforeEach
     void setUp(){
         this.receiver = new DMA_Receiver();
         this.transmitter = new DMA_Transmitter(receiver);

--- a/test/unit/Networking/DMA_TransmitterTest.java
+++ b/test/unit/Networking/DMA_TransmitterTest.java
@@ -24,7 +24,6 @@ class DMA_TransmitterTest {
 
     @Test
     void send() {
-        setUp();
         systemEvent = new DestinationEvent(2, Direction.UP);
         transmitter.send(systemEvent);
         DestinationEvent event = (DestinationEvent) receiver.receive();

--- a/test/unit/Networking/README.md
+++ b/test/unit/Networking/README.md
@@ -2,7 +2,7 @@
 * Last Edited: 2024/02/03
 
 ## Description
-Unit tests for applicable Networking classes.
+Unit tests for applicable Messaging classes.
 
 ## Contents
 * `DMA_ReceiverTest.java`


### PR DESCRIPTION
Networking module - reorganized
- Networking module renamed to messaging
- "Events" folder split up into events and commands to match new subclasses

Reworked Dispatcher to fix scheduler message and a new floor message.
- Created two new message types, one addressed to scheduler, one to floor
- PassengerArrivedCommand, sent to Floor. Encapsulates a destinationEvent + a floor key so we can send a passenger to a specific floor.
- FloorRequestEvent sent to Scheduler. Encapsulates a destinationEvent + a time to map destinations to their request time (allows us to prioritize during scheduling)

Added a new scheduler prioritization algorithm to serve floor requests with an empty elevator
- Changed floor requests from a set of destination events to a map mapping them to their time requested to allow scheduling to fight process hunger (anti-starvation).
- getOldestFloorDirFromElevator: gives the elevator the direction needed to reach the oldest floor.  