### PR TITLE
Configurator Handles Input Filename

### DIFF
--- a/res/system-config-00.json
+++ b/res/system-config-00.json
@@ -2,5 +2,6 @@
   "numFloors": 8,
   "numElevators": 1,
   "travelTime": 8500,
-  "loadTime": 1000
+  "loadTime": 1000,
+  "inputFilename": "test/resources/test-input-file.txt"
 }

--- a/src/Configuration/Config.java
+++ b/src/Configuration/Config.java
@@ -13,6 +13,7 @@ public class Config {
     private final int numElevators;
     private final long travelTime;
     private final long loadTime;
+    private final String inputFilename;
 
     /* Constructors */
 
@@ -24,6 +25,7 @@ public class Config {
         this.numElevators = 0;
         this.travelTime = 0;
         this.loadTime = 0;
+        this.inputFilename = "";
     }
 
     /* Methods */
@@ -44,12 +46,17 @@ public class Config {
         return loadTime;
     }
 
+    public String getInputFilename() {
+        return inputFilename;
+    }
+
     public void printConfig() {
         System.out.println("Launching system under the following configuration:");
         System.out.println("-- numFloors: " + getNumFloors());
         System.out.println("-- numElevators: " + getNumElevators());
         System.out.println("-- travelTime: " + getTravelTime() + " [ms]");
         System.out.println("-- loadTime: " + getLoadTime() + " [ms]");
+        System.out.println("-- inputFilename: " + getInputFilename());
         System.out.println();
     }
 

--- a/src/Main.java
+++ b/src/Main.java
@@ -36,6 +36,7 @@ public class Main {
         config.printConfig();
         int numFloors = config.getNumFloors();
         int numElevators = config.getNumElevators();
+        String inputFilename = config.getInputFilename();
 
         // 2. Create receivers
         TransceiverFactory transceiverFactory = new TransceiverDMAFactory();
@@ -70,8 +71,6 @@ public class Main {
         // 5. Instantiate Parser and parse input file to FloorInputEvents
         System.out.println("\n****** Generating System Input Events ******\n");
         Parser parser = new Parser();
-        //String inputFilename = "res/input-file.txt";
-        String inputFilename = "test/resources/test-input-file.txt";
         ArrayList<FloorInputEvent> inputEvents = parser.parse(inputFilename);
 
         // Start dispatcher (want all systems to be ready before sending events)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] ✅ Test
- [x] 🧑‍💻 Refactor

## Description
Just move input filename specification from hard-coded in main to in JSON config file, since it will maybe be less of a PITA to change frequently when writing different scenarios, which we will be doing shortly. 

## How to test
Supply the pathed input filename you want to use in the config JSON, run and verify it takes your config.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: because nothing to test
- [ ] I need help with writing tests:.

## Screenshots