### PR TITLE
Refactor Scheduler into State Pattern

### DIFF
--- a/src/Subsystem/SchedulerSubsystem/BindingReceiverState.java
+++ b/src/Subsystem/SchedulerSubsystem/BindingReceiverState.java
@@ -40,19 +40,19 @@ public class BindingReceiverState extends State {
      */
     @Override
     public void entry() {
-        System.out.println("*** Scheduler:BindingReceiverState:Entry");
+        System.out.println("[INFO::FSM] Scheduler:BindingReceiverState:Entry");
 
             Class<? extends Subsystem> subsystemType = event.subsystemType();
 
             // Case: Subsystem is Elevator
             if (subsystemType.equals(Elevator.class)) {
                 ((Scheduler)context).transmitterToElevator.addReceiver(event.receiver());
-                System.out.println("--Bound Elevator to Receiver");
+                System.out.println("Scheduler: Bound Elevator to Receiver");
             } 
             // Case: Subsystem is Floor
             else if (subsystemType.equals(Floor.class)) {
                 ((Scheduler)context).transmitterToFloor.addReceiver(event.receiver());
-                System.out.println("--Bound Floor to Receiver");
+                System.out.println("Scheduler: Bound Floor to Receiver");
             } 
             // Case: Subsystem is BAD
             else {
@@ -70,10 +70,10 @@ public class BindingReceiverState extends State {
      */
     @Override
     public void doActivity() {
-        System.out.println("*** Scheduler:BindingReceiverState:Do");
+        System.out.println("[INFO::FSM] Scheduler:BindingReceiverState:Do");
 
         // Next State: BindingReceiverState
-        // Required Constructor Arguments: NA
+        // Required Constructor Arguments: context
         context.setNextState(new ReceivingState(context));
 
     }
@@ -83,11 +83,9 @@ public class BindingReceiverState extends State {
      */
     @Override
     public void exit() {
-        System.out.println("*** Scheduler:BindingReceiverState:Exit");
+        System.out.println("[INFO::FSM] Scheduler:BindingReceiverState:Exit");
         // Only do this here if exit activities affect next state selection.
         //context.setNextState(new BindingReceiverState(context));
     }
 
 }
-
-

--- a/src/Subsystem/SchedulerSubsystem/BindingReceiverState.java
+++ b/src/Subsystem/SchedulerSubsystem/BindingReceiverState.java
@@ -79,11 +79,6 @@ public class BindingReceiverState extends State {
     @Override
     public void doActivity() {
         System.out.println("[INFO::FSM] Scheduler:BindingReceiverState:Do");
-
-        // Next State: BindingReceiverState
-        // Required Constructor Arguments: context
-        context.setNextState(new ReceivingState(context));
-
     }
 
     /**
@@ -92,6 +87,9 @@ public class BindingReceiverState extends State {
     @Override
     public void exit() {
         System.out.println("[INFO::FSM] Scheduler:BindingReceiverState:Exit");
+        // Next State: BindingReceiverState
+        // Required Constructor Arguments: context
+        context.setNextState(new ReceivingState(context));
     }
 
 }

--- a/src/Subsystem/SchedulerSubsystem/BindingReceiverState.java
+++ b/src/Subsystem/SchedulerSubsystem/BindingReceiverState.java
@@ -56,13 +56,11 @@ public class BindingReceiverState extends State {
 
             // Case: Subsystem is Elevator
             if (subsystemType.equals(Elevator.class)) {
-                ((Scheduler)context).transmitterToElevator.addReceiver(event.receiver());
-                System.out.println("Scheduler: Bound Elevator to Receiver");
+                ((Scheduler)context).bindElevatorReceiver(event.receiver());
             } 
             // Case: Subsystem is Floor
             else if (subsystemType.equals(Floor.class)) {
-                ((Scheduler)context).transmitterToFloor.addReceiver(event.receiver());
-                System.out.println("Scheduler: Bound Floor to Receiver");
+                ((Scheduler)context).bindFloorReceiver(event.receiver());
             } 
             // Case: Subsystem is BAD
             else {

--- a/src/Subsystem/SchedulerSubsystem/BindingReceiverState.java
+++ b/src/Subsystem/SchedulerSubsystem/BindingReceiverState.java
@@ -14,6 +14,17 @@ import Subsystem.FloorSubsystem.Floor;
 import Subsystem.Subsystem;
 import com.sun.jdi.InvalidTypeException;
 
+/**
+ * Scheduler FSM State: Binding Receiver State.
+ *
+ * Class which models the Binding Receiver State of the Scheduler FSM.
+ *
+ * Responsibilities:
+ * - Bind a Receiver to Elevator or Floor Subsystem.
+ *
+ * @author MD
+ * @version Iteration-3
+ */
 public class BindingReceiverState extends State {
 
     /* Instance Variables */
@@ -25,7 +36,6 @@ public class BindingReceiverState extends State {
      * Parametric constructor.
      *
      * @param context Context of state machine that this is a state of.
-     * @author MD
      */
     public BindingReceiverState(Context context, ReceiverBindingEvent event) {
         super(context);
@@ -84,8 +94,6 @@ public class BindingReceiverState extends State {
     @Override
     public void exit() {
         System.out.println("[INFO::FSM] Scheduler:BindingReceiverState:Exit");
-        // Only do this here if exit activities affect next state selection.
-        //context.setNextState(new BindingReceiverState(context));
     }
 
 }

--- a/src/Subsystem/SchedulerSubsystem/BindingReceiverState.java
+++ b/src/Subsystem/SchedulerSubsystem/BindingReceiverState.java
@@ -1,0 +1,93 @@
+package Subsystem.SchedulerSubsystem;
+
+import Messaging.Messages.Commands.MoveElevatorCommand;
+import Messaging.Messages.Events.DestinationEvent;
+import Messaging.Messages.Events.ElevatorStateEvent;
+import Messaging.Messages.Events.FloorRequestEvent;
+import Messaging.Messages.Events.ReceiverBindingEvent;
+import Messaging.Messages.SystemMessage;
+import Messaging.Messages.Commands.SendPassengersCommand;
+import StatePatternLib.Context;
+import StatePatternLib.State;
+import Subsystem.ElevatorSubsytem.Elevator;
+import Subsystem.FloorSubsystem.Floor;
+import Subsystem.Subsystem;
+import com.sun.jdi.InvalidTypeException;
+
+public class BindingReceiverState extends State {
+
+    /* Instance Variables */
+    
+    // The ReceiverBindingEvent to process
+    private ReceiverBindingEvent event;
+
+    /**
+     * Parametric constructor.
+     *
+     * @param context Context of state machine that this is a state of.
+     * @author MD
+     */
+    public BindingReceiverState(Context context, ReceiverBindingEvent event) {
+        super(context);
+        // Initialize the ReceiverBindingEvent that needs processing in this state.
+        this.event = event;
+    }
+
+    /**
+     * Entry activities for this state.
+     *
+     * In this state, we just handle Binding of Receivers.
+     */
+    @Override
+    public void entry() {
+        System.out.println("*** Scheduler:BindingReceiverState:Entry");
+
+            Class<? extends Subsystem> subsystemType = event.subsystemType();
+
+            // Case: Subsystem is Elevator
+            if (subsystemType.equals(Elevator.class)) {
+                ((Scheduler)context).transmitterToElevator.addReceiver(event.receiver());
+                System.out.println("--Bound Elevator to Receiver");
+            } 
+            // Case: Subsystem is Floor
+            else if (subsystemType.equals(Floor.class)) {
+                ((Scheduler)context).transmitterToFloor.addReceiver(event.receiver());
+                System.out.println("--Bound Floor to Receiver");
+            } 
+            // Case: Subsystem is BAD
+            else {
+                try {
+                    throw new InvalidTypeException("Unknown subsystem (" + subsystemType + ") attempted to bind to scheduler.");
+                } catch (InvalidTypeException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+    }
+
+    /**
+     * Do activities for this state.
+     *
+     */
+    @Override
+    public void doActivity() {
+        System.out.println("*** Scheduler:BindingReceiverState:Do");
+
+        // Next State: BindingReceiverState
+        // Required Constructor Arguments: NA
+        context.setNextState(new ReceivingState(context));
+
+    }
+
+    /**
+     * Exit activities for this state.
+     */
+    @Override
+    public void exit() {
+        System.out.println("*** Scheduler:BindingReceiverState:Exit");
+        // Only do this here if exit activities affect next state selection.
+        //context.setNextState(new BindingReceiverState(context));
+    }
+
+}
+
+

--- a/src/Subsystem/SchedulerSubsystem/LoadingPassengerState.java
+++ b/src/Subsystem/SchedulerSubsystem/LoadingPassengerState.java
@@ -1,0 +1,74 @@
+package Subsystem.SchedulerSubsystem;
+
+import Messaging.Messages.Commands.MoveElevatorCommand;
+import Messaging.Messages.Events.DestinationEvent;
+import Messaging.Messages.Events.ElevatorStateEvent;
+import Messaging.Messages.Events.FloorRequestEvent;
+import Messaging.Messages.Events.PassengerLoadEvent;
+import Messaging.Messages.SystemMessage;
+import Messaging.Messages.Commands.SendPassengersCommand;
+import Messaging.Messages.Commands.MovePassengersCommand;
+import StatePatternLib.Context;
+import StatePatternLib.State;
+import com.sun.jdi.InvalidTypeException;
+
+public class LoadingPassengerState extends State {
+
+    /* Instance Variables */
+    
+    // The PassengerLoadEvent to process
+    private PassengerLoadEvent event;
+
+    /**
+     * Parametric constructor.
+     *
+     * @param context Context of state machine that this is a state of.
+     * @author MD
+     */
+    public LoadingPassengerState(Context context, PassengerLoadEvent event) {
+        super(context);
+        // Initialize the PassengerLoadEvent that needs processing in this state.
+        this.event = event;
+    }
+
+    /**
+     * Entry activities for this state.
+     */
+    @Override
+    public void entry() {
+        System.out.println("*** Scheduler:LoadingPassengerState:Entry");
+    }
+
+    /**
+     * Do activities for this state.
+     *
+     * In this state, we just transmit a MovePassengersCommand to an Elevator,
+     * and then return to Receiving state (for now, at least).
+     */
+    @Override
+    public void doActivity() {
+        System.out.println("*** Scheduler:LoadingPassengerState:Do");
+
+        // Load Passengers, notify Elevator
+        MovePassengersCommand movePassengersCommand = new MovePassengersCommand(event.elevNumber(), event.passengers());
+        // TODO: Replace with method call when implemented
+        ((Scheduler)context).transmitterToElevator.send(movePassengersCommand);
+
+        // Next State: ReceivingState
+        // Required Constructor Arguments: NA
+        context.setNextState(new ReceivingState(context));
+    }
+
+    /**
+     * Exit activities for this state.
+     */
+    @Override
+    public void exit() {
+        System.out.println("*** Scheduler:LoadingPassengerState:Exit");
+        // Only do this here if exit activities affect next state selection.
+        //context.setNextState(new LoadingPassengerState(context));
+    }
+
+}
+
+

--- a/src/Subsystem/SchedulerSubsystem/LoadingPassengerState.java
+++ b/src/Subsystem/SchedulerSubsystem/LoadingPassengerState.java
@@ -36,7 +36,7 @@ public class LoadingPassengerState extends State {
      */
     @Override
     public void entry() {
-        System.out.println("*** Scheduler:LoadingPassengerState:Entry");
+        System.out.println("[INFO::FSM] Scheduler:LoadingPassengerState:Entry");
     }
 
     /**
@@ -47,7 +47,7 @@ public class LoadingPassengerState extends State {
      */
     @Override
     public void doActivity() {
-        System.out.println("*** Scheduler:LoadingPassengerState:Do");
+        System.out.println("[INFO::FSM] Scheduler:LoadingPassengerState:Do");
 
         // Load Passengers, notify Elevator
         MovePassengersCommand movePassengersCommand = new MovePassengersCommand(event.elevNumber(), event.passengers());
@@ -55,7 +55,7 @@ public class LoadingPassengerState extends State {
         ((Scheduler)context).transmitterToElevator.send(movePassengersCommand);
 
         // Next State: ReceivingState
-        // Required Constructor Arguments: NA
+        // Required Constructor Arguments: context
         context.setNextState(new ReceivingState(context));
     }
 
@@ -64,11 +64,9 @@ public class LoadingPassengerState extends State {
      */
     @Override
     public void exit() {
-        System.out.println("*** Scheduler:LoadingPassengerState:Exit");
+        System.out.println("[INFO::FSM] Scheduler:LoadingPassengerState:Exit");
         // Only do this here if exit activities affect next state selection.
         //context.setNextState(new LoadingPassengerState(context));
     }
 
 }
-
-

--- a/src/Subsystem/SchedulerSubsystem/LoadingPassengerState.java
+++ b/src/Subsystem/SchedulerSubsystem/LoadingPassengerState.java
@@ -63,10 +63,6 @@ public class LoadingPassengerState extends State {
         // Load Passengers, notify Elevator
         MovePassengersCommand movePassengersCommand = new MovePassengersCommand(event.elevNumber(), event.passengers());
         ((Scheduler)context).transmitToElevator(movePassengersCommand);
-
-        // Next State: ReceivingState
-        // Required Constructor Arguments: context
-        context.setNextState(new ReceivingState(context));
     }
 
     /**
@@ -75,6 +71,9 @@ public class LoadingPassengerState extends State {
     @Override
     public void exit() {
         System.out.println("[INFO::FSM] Scheduler:LoadingPassengerState:Exit");
+        // Next State: ReceivingState
+        // Required Constructor Arguments: context
+        context.setNextState(new ReceivingState(context));
     }
 
 }

--- a/src/Subsystem/SchedulerSubsystem/LoadingPassengerState.java
+++ b/src/Subsystem/SchedulerSubsystem/LoadingPassengerState.java
@@ -62,8 +62,7 @@ public class LoadingPassengerState extends State {
 
         // Load Passengers, notify Elevator
         MovePassengersCommand movePassengersCommand = new MovePassengersCommand(event.elevNumber(), event.passengers());
-        // TODO: Replace with method call when implemented
-        ((Scheduler)context).transmitterToElevator.send(movePassengersCommand);
+        ((Scheduler)context).transmitToElevator(movePassengersCommand);
 
         // Next State: ReceivingState
         // Required Constructor Arguments: context

--- a/src/Subsystem/SchedulerSubsystem/LoadingPassengerState.java
+++ b/src/Subsystem/SchedulerSubsystem/LoadingPassengerState.java
@@ -12,6 +12,17 @@ import StatePatternLib.Context;
 import StatePatternLib.State;
 import com.sun.jdi.InvalidTypeException;
 
+/**
+ * Scheduler FSM State: Loading Passenger State.
+ *
+ * Class which models the Loading Passenger State of the Scheduler FSM.
+ *
+ * Responsibilities:
+ * - Command an Elevator to load Passengers.
+ *
+ * @author MD
+ * @version Iteration-3
+ */
 public class LoadingPassengerState extends State {
 
     /* Instance Variables */
@@ -43,7 +54,7 @@ public class LoadingPassengerState extends State {
      * Do activities for this state.
      *
      * In this state, we just transmit a MovePassengersCommand to an Elevator,
-     * and then return to Receiving state (for now, at least).
+     * and then return to Receiving state.
      */
     @Override
     public void doActivity() {
@@ -65,8 +76,6 @@ public class LoadingPassengerState extends State {
     @Override
     public void exit() {
         System.out.println("[INFO::FSM] Scheduler:LoadingPassengerState:Exit");
-        // Only do this here if exit activities affect next state selection.
-        //context.setNextState(new LoadingPassengerState(context));
     }
 
 }

--- a/src/Subsystem/SchedulerSubsystem/ProcessingElevatorEventState.java
+++ b/src/Subsystem/SchedulerSubsystem/ProcessingElevatorEventState.java
@@ -81,7 +81,7 @@ public class ProcessingElevatorEventState extends State {
             System.out.printf("Elevator %s stopped.%n", event.elevatorNum());
 
             // Notify Floor for service
-            ((Scheduler)context).transmitterToFloor.send(new SendPassengersCommand(event.currentFloor(), event.elevatorNum(), ((Scheduler)context).getElevatorDirection(event)));
+            ((Scheduler)context).transmitToFloor(new SendPassengersCommand(event.currentFloor(), event.elevatorNum(), ((Scheduler)context).getElevatorDirection(event)));
 
             // Remove the serviced Floor request
             ((Scheduler)context).floorRequestsToTime.remove(new DestinationEvent(event.currentFloor(),((Scheduler)context).getElevatorDirection(event)));
@@ -96,7 +96,7 @@ public class ProcessingElevatorEventState extends State {
         else {
 
             // Request Elevator to keep moving
-            ((Scheduler)context).transmitterToElevator.send(new MoveElevatorCommand(event.elevatorNum(), ((Scheduler)context).getElevatorDirection(event)));
+            ((Scheduler)context).transmitToElevator(new MoveElevatorCommand(event.elevatorNum(), ((Scheduler)context).getElevatorDirection(event)));
 
             // Next State: ReceivingState
             // Required Constructor Arguments: context

--- a/src/Subsystem/SchedulerSubsystem/ProcessingElevatorEventState.java
+++ b/src/Subsystem/SchedulerSubsystem/ProcessingElevatorEventState.java
@@ -34,7 +34,7 @@ public class ProcessingElevatorEventState extends State {
      */
     @Override
     public void entry() {
-        System.out.println("*** Scheduler:ProcessingElevatorEventState:Entry");
+        System.out.println("[INFO::FSM] Scheduler:ProcessingElevatorEventState:Entry");
     }
 
     /**
@@ -46,21 +46,21 @@ public class ProcessingElevatorEventState extends State {
      */
     @Override
     public void doActivity() {
-        System.out.println("*** Scheduler:ProcessingElevatorEventState:Do");
+        System.out.println("[INFO::FSM] Scheduler:ProcessingElevatorEventState:Do");
 
         // Case: Elevator indicates it is Idle.
         // Description: Elevator has neither Floors nor Passengers to service, and is
         //              not in motion. It's just chillin'.
         if (((Scheduler)context).floorRequestsToTime.isEmpty() && event.passengerCountMap().isEmpty()) {
 
-            System.out.printf("Elevator %s idle%n", event.elevatorNum());
+            System.out.printf("Schduler: Elevator %s idle%n", event.elevatorNum());
 
             // Register this Elevator as Idle
             //((Scheduler)context).idleElevators.add(event);
             ((Scheduler)context).addIdleElevator(event);
 
             // Next State: ReceivingState
-            // Required Constructor Arguments: NA
+            // Required Constructor Arguments: context
             context.setNextState(new ReceivingState(context)); 
         } 
         // Case: Elevator indicates it is Stopping.
@@ -76,7 +76,7 @@ public class ProcessingElevatorEventState extends State {
 
 
             // Next State: ReceivingState
-            // Required Constructor Arguments: NA
+            // Required Constructor Arguments: context
             context.setNextState(new ReceivingState(context)); 
 
             // NB: Tried this instead, it did bad things.
@@ -90,7 +90,7 @@ public class ProcessingElevatorEventState extends State {
             ((Scheduler)context).transmitterToElevator.send(new MoveElevatorCommand(event.elevatorNum(), ((Scheduler)context).getElevatorDirection(event)));
 
             // Next State: ReceivingState
-            // Required Constructor Arguments: NA
+            // Required Constructor Arguments: context
             context.setNextState(new ReceivingState(context)); 
         }
 
@@ -101,7 +101,7 @@ public class ProcessingElevatorEventState extends State {
      */
     @Override
     public void exit() {
-        System.out.println("*** Scheduler:ProcessingElevatorEventState:Exit");
+        System.out.println("[INFO::FSM] Scheduler:ProcessingElevatorEventState:Exit");
         // Only do this here if exit activities affect next state selection.
         //context.setNextState(new ProcessingElevatorEventState(context));
     }

--- a/src/Subsystem/SchedulerSubsystem/ProcessingElevatorEventState.java
+++ b/src/Subsystem/SchedulerSubsystem/ProcessingElevatorEventState.java
@@ -10,6 +10,19 @@ import StatePatternLib.Context;
 import StatePatternLib.State;
 import com.sun.jdi.InvalidTypeException;
 
+/**
+ * Scheduler FSM State: Processing Elevator Event State.
+ *
+ * Class which models the Processing Elevator Event State of the Scheduler FSM.
+ *
+ * Responsibilities:
+ * - Determine if Elevator is in service or is idle
+ * - Initiate service if Elevator is stopping at a Floor
+ * - Keep the Elevator moving if does not need to stop at a Floor
+ *
+ * @author MD
+ * @version Iteration-3
+ */
 public class ProcessingElevatorEventState extends State {
 
     /* Instance Variables */
@@ -21,7 +34,6 @@ public class ProcessingElevatorEventState extends State {
      * Parametric constructor.
      *
      * @param context Context of state machine that this is a state of.
-     * @author MD
      */
     public ProcessingElevatorEventState(Context context, ElevatorStateEvent event) {
         super(context);
@@ -74,13 +86,10 @@ public class ProcessingElevatorEventState extends State {
             // Remove the serviced Floor request
             ((Scheduler)context).floorRequestsToTime.remove(new DestinationEvent(event.currentFloor(),((Scheduler)context).getElevatorDirection(event)));
 
-
             // Next State: ReceivingState
             // Required Constructor Arguments: context
             context.setNextState(new ReceivingState(context)); 
 
-            // NB: Tried this instead, it did bad things.
-            //context.setNextState(new LoadingPassengerState(context, passengerLoadEvent)); 
         }
         // Case: Elevator indicates it is Moving.
         // Description: Keep calm, carry on. It'll be okay. You'll get there buddy.
@@ -102,10 +111,6 @@ public class ProcessingElevatorEventState extends State {
     @Override
     public void exit() {
         System.out.println("[INFO::FSM] Scheduler:ProcessingElevatorEventState:Exit");
-        // Only do this here if exit activities affect next state selection.
-        //context.setNextState(new ProcessingElevatorEventState(context));
     }
 
 }
-
-

--- a/src/Subsystem/SchedulerSubsystem/ProcessingElevatorEventState.java
+++ b/src/Subsystem/SchedulerSubsystem/ProcessingElevatorEventState.java
@@ -3,6 +3,7 @@ package Subsystem.SchedulerSubsystem;
 import Messaging.Messages.Commands.MoveElevatorCommand;
 import Messaging.Messages.Events.DestinationEvent;
 import Messaging.Messages.Events.ElevatorStateEvent;
+import Messaging.Messages.Events.PassengerLoadEvent;
 import Messaging.Messages.SystemMessage;
 import Messaging.Messages.Commands.SendPassengersCommand;
 import StatePatternLib.Context;
@@ -68,19 +69,18 @@ public class ProcessingElevatorEventState extends State {
             System.out.printf("Elevator %s stopped.%n", event.elevatorNum());
 
             // Notify Floor for service
-            ((Scheduler)context).transmitterToFloor.send(new SendPassengersCommand(event.currentFloor(),
-                    event.elevatorNum(),
-                    ((Scheduler)context).getElevatorDirection(event)));
+            ((Scheduler)context).transmitterToFloor.send(new SendPassengersCommand(event.currentFloor(), event.elevatorNum(), ((Scheduler)context).getElevatorDirection(event)));
 
             // Remove the serviced Floor request
-            // NB: Delegate to next state?
             ((Scheduler)context).floorRequestsToTime.remove(new DestinationEvent(event.currentFloor(),((Scheduler)context).getElevatorDirection(event)));
 
-            // Next State: LoadingPassengerState
+
+            // Next State: ReceivingState
             // Required Constructor Arguments: NA
-            //context.setNextState(new LoadingPassengerState(context)); 
-            // CHEAT CODE: Back to RecevingState for now
             context.setNextState(new ReceivingState(context)); 
+
+            // NB: Tried this instead, it did bad things.
+            //context.setNextState(new LoadingPassengerState(context, passengerLoadEvent)); 
         }
         // Case: Elevator indicates it is Moving.
         // Description: Keep calm, carry on. It'll be okay. You'll get there buddy.

--- a/src/Subsystem/SchedulerSubsystem/ProcessingElevatorEventState.java
+++ b/src/Subsystem/SchedulerSubsystem/ProcessingElevatorEventState.java
@@ -55,7 +55,8 @@ public class ProcessingElevatorEventState extends State {
             System.out.printf("Elevator %s idle%n", event.elevatorNum());
 
             // Register this Elevator as Idle
-            ((Scheduler)context).idleElevators.add(event);
+            //((Scheduler)context).idleElevators.add(event);
+            ((Scheduler)context).addIdleElevator(event);
 
             // Next State: ReceivingState
             // Required Constructor Arguments: NA

--- a/src/Subsystem/SchedulerSubsystem/ProcessingElevatorEventState.java
+++ b/src/Subsystem/SchedulerSubsystem/ProcessingElevatorEventState.java
@@ -63,12 +63,11 @@ public class ProcessingElevatorEventState extends State {
         // Case: Elevator indicates it is Idle.
         // Description: Elevator has neither Floors nor Passengers to service, and is
         //              not in motion. It's just chillin'.
-        if (((Scheduler)context).floorRequestsToTime.isEmpty() && event.passengerCountMap().isEmpty()) {
+        if (!((Scheduler)context).hasPendingDestinationEvents() && event.passengerCountMap().isEmpty()) {
 
-            System.out.printf("Schduler: Elevator %s idle%n", event.elevatorNum());
+            System.out.printf("Scheduler: Elevator %s idle%n", event.elevatorNum());
 
             // Register this Elevator as Idle
-            //((Scheduler)context).idleElevators.add(event);
             ((Scheduler)context).addIdleElevator(event);
 
             // Next State: ReceivingState
@@ -83,8 +82,8 @@ public class ProcessingElevatorEventState extends State {
             // Notify Floor for service
             ((Scheduler)context).transmitToFloor(new SendPassengersCommand(event.currentFloor(), event.elevatorNum(), ((Scheduler)context).getElevatorDirection(event)));
 
-            // Remove the serviced Floor request
-            ((Scheduler)context).floorRequestsToTime.remove(new DestinationEvent(event.currentFloor(),((Scheduler)context).getElevatorDirection(event)));
+            // Remove the serviced DestinationRequest request
+            ((Scheduler)context).removeDestinationEvent(new DestinationEvent(event.currentFloor(),((Scheduler)context).getElevatorDirection(event)));
 
             // Next State: ReceivingState
             // Required Constructor Arguments: context

--- a/src/Subsystem/SchedulerSubsystem/ProcessingElevatorEventState.java
+++ b/src/Subsystem/SchedulerSubsystem/ProcessingElevatorEventState.java
@@ -1,0 +1,110 @@
+package Subsystem.SchedulerSubsystem;
+
+import Messaging.Messages.Commands.MoveElevatorCommand;
+import Messaging.Messages.Events.DestinationEvent;
+import Messaging.Messages.Events.ElevatorStateEvent;
+import Messaging.Messages.SystemMessage;
+import Messaging.Messages.Commands.SendPassengersCommand;
+import StatePatternLib.Context;
+import StatePatternLib.State;
+import com.sun.jdi.InvalidTypeException;
+
+public class ProcessingElevatorEventState extends State {
+
+    /* Instance Variables */
+    
+    // The ElevatorStentEvent to process
+    private ElevatorStateEvent event;
+
+    /**
+     * Parametric constructor.
+     *
+     * @param context Context of state machine that this is a state of.
+     * @author MD
+     */
+    public ProcessingElevatorEventState(Context context, ElevatorStateEvent event) {
+        super(context);
+        // Initialize the ElevatorStateEvent that needs processing in this state.
+        this.event = event;
+    }
+
+    /**
+     * Entry activities for this state.
+     */
+    @Override
+    public void entry() {
+        System.out.println("*** Scheduler:ProcessingElevatorEventState:Entry");
+    }
+
+    /**
+     * Do activities for this state.
+     *
+     * In this state, we process an ElevatorStateEvent received from an Elevator,
+     * which indicates its state, and then determine the apopropriate action for
+     * that Elevator to take.
+     */
+    @Override
+    public void doActivity() {
+        System.out.println("*** Scheduler:ProcessingElevatorEventState:Do");
+
+        // Case: Elevator indicates it is Idle.
+        // Description: Elevator has neither Floors nor Passengers to service, and is
+        //              not in motion. It's just chillin'.
+        if (((Scheduler)context).floorRequestsToTime.isEmpty() && event.passengerCountMap().isEmpty()) {
+
+            System.out.printf("Elevator %s idle%n", event.elevatorNum());
+
+            // Register this Elevator as Idle
+            ((Scheduler)context).idleElevators.add(event);
+
+            // Next State: ReceivingState
+            // Required Constructor Arguments: NA
+            context.setNextState(new ReceivingState(context)); 
+        } 
+        // Case: Elevator indicates it is Stopping.
+        // Description: Since the Elevator is stopping, it must be servicing this Floor.
+        else if (((Scheduler)context).isElevatorStopping(event)) { 
+            System.out.printf("Elevator %s stopped.%n", event.elevatorNum());
+
+            // Notify Floor for service
+            ((Scheduler)context).transmitterToFloor.send(new SendPassengersCommand(event.currentFloor(),
+                    event.elevatorNum(),
+                    ((Scheduler)context).getElevatorDirection(event)));
+
+            // Remove the serviced Floor request
+            // NB: Delegate to next state?
+            ((Scheduler)context).floorRequestsToTime.remove(new DestinationEvent(event.currentFloor(),((Scheduler)context).getElevatorDirection(event)));
+
+            // Next State: LoadingPassengerState
+            // Required Constructor Arguments: NA
+            //context.setNextState(new LoadingPassengerState(context)); 
+            // CHEAT CODE: Back to RecevingState for now
+            context.setNextState(new ReceivingState(context)); 
+        }
+        // Case: Elevator indicates it is Moving.
+        // Description: Keep calm, carry on. It'll be okay. You'll get there buddy.
+        else {
+
+            // Request Elevator to keep moving
+            ((Scheduler)context).transmitterToElevator.send(new MoveElevatorCommand(event.elevatorNum(), ((Scheduler)context).getElevatorDirection(event)));
+
+            // Next State: ReceivingState
+            // Required Constructor Arguments: NA
+            context.setNextState(new ReceivingState(context)); 
+        }
+
+    }
+
+    /**
+     * Exit activities for this state.
+     */
+    @Override
+    public void exit() {
+        System.out.println("*** Scheduler:ProcessingElevatorEventState:Exit");
+        // Only do this here if exit activities affect next state selection.
+        //context.setNextState(new ProcessingElevatorEventState(context));
+    }
+
+}
+
+

--- a/src/Subsystem/SchedulerSubsystem/ReceivingState.java
+++ b/src/Subsystem/SchedulerSubsystem/ReceivingState.java
@@ -70,15 +70,10 @@ public class ReceivingState extends State {
         else if (event instanceof PassengerLoadEvent plEvent) {
             System.out.println("*** Scheduler:ReceivingState:Entry: Received PassengerLoadEvent.");
             // Next State: LoadingPassengerState
-            // Required Constructor Arguments: NA
-            //context.setNextState(new LoadingPassengerState(context));
+            // Required Constructor Arguments: PassengerLoadEvent
+            context.setNextState(new LoadingPassengerState(context, plEvent));
             // CHEAT CODE: Back to ReceivingState for now
-            context.setNextState(new ReceivingState(context)); 
-
-            /* STATE LOGIC - MOVE TO STATE */ 
-            //transmitterToElevator.send(new MovePassengersCommand(plEvent.elevNumber(), plEvent.passengers())); // put inside state
-            // context.movePassenger
-            // setNextState
+            //context.setNextState(new ReceivingState(context)); 
         } 
         // Case: Event is ReceiverBindingEvent
         // Description: Request to bind a Receiver to this Scheduler Subsystem

--- a/src/Subsystem/SchedulerSubsystem/ReceivingState.java
+++ b/src/Subsystem/SchedulerSubsystem/ReceivingState.java
@@ -61,9 +61,9 @@ public class ReceivingState extends State {
             System.out.println("*** Scheduler:ReceivingState:Entry: Received FloorRequestEvent.");
             // Next State: StoringFloorRequestState
             // Required Constructor Arguments: NA
-            //context.setNextState(new StoringFloorRequestState(context)); 
+            context.setNextState(new StoringFloorRequestState(context, frEvent)); 
             // CHEAT CODE: Back to ReceivingState for now
-            context.setNextState(new ReceivingState(context)); 
+            //context.setNextState(new ReceivingState(context)); 
         }
         // Case: Event is PassengerLoadEvent
         // Description: Notification from Floor of Passengers requiring load

--- a/src/Subsystem/SchedulerSubsystem/ReceivingState.java
+++ b/src/Subsystem/SchedulerSubsystem/ReceivingState.java
@@ -9,6 +9,17 @@ import StatePatternLib.Context;
 import StatePatternLib.State;
 import com.sun.jdi.InvalidTypeException;
 
+/**
+ * Scheduler FSM State: Receiving State.
+ *
+ * Class which models the Receiving State of the Scheduler FSM.
+ *
+ * Responsibilities:
+ * - 
+ *
+ * @author AA/MD
+ * @version Iteration-3
+ */
 public class ReceivingState extends State {
 
     /* Instance Variables */
@@ -20,7 +31,6 @@ public class ReceivingState extends State {
      * Parametric constructor.
      *
      * @param context Context of state machine that this is a state of.
-     * @author AA/MD
      */
     public ReceivingState(Context context) {
         super(context);
@@ -98,10 +108,6 @@ public class ReceivingState extends State {
     @Override
     public void exit() {
         System.out.println("[INFO::FSM] Scheduler:ReceivingState:Exit");
-        // Only do this here if exit activities affect next state selection.
-        //context.setNextState(new ReceivingState(context));
     }
 
 }
-
-

--- a/src/Subsystem/SchedulerSubsystem/ReceivingState.java
+++ b/src/Subsystem/SchedulerSubsystem/ReceivingState.java
@@ -31,7 +31,7 @@ public class ReceivingState extends State {
      */
     @Override
     public void entry() {
-        System.out.println("*** Scheduler:ReceivingState:Entry");
+        System.out.println("[INFO::FSM] Scheduler:ReceivingState:Entry");
         // Get the SystemMessage (pop from Receiver buffer)
         event = ((Scheduler) context).receive();
     }
@@ -45,22 +45,22 @@ public class ReceivingState extends State {
      */
     @Override
     public void doActivity() {
-        System.out.println("*** Scheduler:ReceivingState:Do");
+        System.out.println("[INFO::FSM] Scheduler:ReceivingState:Do");
 
         // Case: Event is ElevatorStateEvent
         // Description: Notification from Elevator conveying its state
         if (event instanceof ElevatorStateEvent esEvent) {
-            System.out.println("*** Scheduler:ReceivingState:Entry: Received ElevatorStateEvent.");
+            System.out.println("[INFO::FSM] Scheduler:ReceivingState:Entry: Received ElevatorStateEvent.");
             // Next State: ProcessingElevatorEventState
-            // Required Constructor Arguments: NA
+            // Required Constructor Arguments: context
             context.setNextState(new ProcessingElevatorEventState(context, esEvent)); 
         }
         // Case: Event is FloorRequestEvent
         // Description: Request from Floor asking for service
         else if (event instanceof FloorRequestEvent frEvent) {
-            System.out.println("*** Scheduler:ReceivingState:Entry: Received FloorRequestEvent.");
+            System.out.println("[INFO::FSM] Scheduler:ReceivingState:Entry: Received FloorRequestEvent.");
             // Next State: StoringFloorRequestState
-            // Required Constructor Arguments: NA
+            // Required Constructor Arguments: context
             context.setNextState(new StoringFloorRequestState(context, frEvent)); 
             // CHEAT CODE: Back to ReceivingState for now
             //context.setNextState(new ReceivingState(context)); 
@@ -68,7 +68,7 @@ public class ReceivingState extends State {
         // Case: Event is PassengerLoadEvent
         // Description: Notification from Floor of Passengers requiring load
         else if (event instanceof PassengerLoadEvent plEvent) {
-            System.out.println("*** Scheduler:ReceivingState:Entry: Received PassengerLoadEvent.");
+            System.out.println("[INFO::FSM] Scheduler:ReceivingState:Entry: Received PassengerLoadEvent.");
             // Next State: LoadingPassengerState
             // Required Constructor Arguments: PassengerLoadEvent
             context.setNextState(new LoadingPassengerState(context, plEvent));
@@ -78,7 +78,7 @@ public class ReceivingState extends State {
         // Case: Event is ReceiverBindingEvent
         // Description: Request to bind a Receiver to this Scheduler Subsystem
         else if (event instanceof ReceiverBindingEvent rbEvent) {
-            System.out.println("*** Scheduler:ReceivingState:Entry: Received ReceiverBindingEvent.");
+            System.out.println("[INFO::FSM] Scheduler:ReceivingState:Entry: Received ReceiverBindingEvent.");
             // Next State: BindingReceiverState
             // Required Constructor Arguments: ReceiverBindingEvent
             context.setNextState(new BindingReceiverState(context, rbEvent));
@@ -97,7 +97,7 @@ public class ReceivingState extends State {
      */
     @Override
     public void exit() {
-        System.out.println("*** Scheduler:ReceivingState:Exit\n");
+        System.out.println("[INFO::FSM] Scheduler:ReceivingState:Exit");
         // Only do this here if exit activities affect next state selection.
         //context.setNextState(new ReceivingState(context));
     }

--- a/src/Subsystem/SchedulerSubsystem/ReceivingState.java
+++ b/src/Subsystem/SchedulerSubsystem/ReceivingState.java
@@ -1,0 +1,107 @@
+package Subsystem.SchedulerSubsystem;
+
+import Messaging.Messages.Events.ElevatorStateEvent;
+import Messaging.Messages.SystemMessage;
+import StatePatternLib.Context;
+import StatePatternLib.State;
+import com.sun.jdi.InvalidTypeException;
+
+public class ReceivingState extends State {
+
+    /* Instance Variables */
+    
+    // The event to receive.
+    private SystemMessage event;
+
+    /**
+     * Parametric constructor.
+     *
+     * @param context Context of state machine that this is a state of.
+     * @author AA/MD
+     */
+    public ReceivingState(Context context) {
+        super(context);
+    }
+
+    /**
+     * Entry activities for this state.
+     */
+    @Override
+    public void entry() {
+        // DEBUG
+        System.out.println("\nElevator State: Entering RECEIVING State\n");
+        // Get the SystemMessage (pop from Receiver buffer)
+        event = ((Scheduler) context).receive();
+    }
+
+    /**
+     * Do activities for this state.
+     *
+     * In this state, we simply switch on the received SystemMessage event, and point 
+     * to the next state.
+     */
+    @Override
+    public void doActivity() {
+
+        // Case: Event is ElevatorStateEvent
+        // Description: Notification from Elevator conveying its state
+        if (event instanceof ElevatorStateEvent esEvent) {
+            // Next State: ProcessingElevatorEventState
+            // Required Constructor Arguments: NA
+            context.setNextState(new ProcessingElevatorEventState(context)); 
+        }
+        // Case: Event is FloorRequestEvent
+        // Description: Request from Floor asking for service
+        else if (event instanceof FloorRequestEvent frEvent) {
+            // Next State: StoringFloorRequestState
+            // Required Constructor Arguments: NA
+            context.setNextState(new StoringFloorRequestState(context)); 
+        }
+        // Case: Event is PassengerLoadEvent
+        // Description: Notification from Floor of Passengers requiring load
+        else if (event instanceof PassengerLoadEvent plEvent) {
+            // Next State: LoadingPassengerState
+            // Required Constructor Arguments: NA
+            context.setNextState(new LoadingPassengerState(context));
+
+            /* STATE LOGIC - MOVE TO STATE */ 
+            //transmitterToElevator.send(new MovePassengersCommand(plEvent.elevNumber(), plEvent.passengers())); // put inside state
+            // context.movePassenger
+            // setNextState
+        } 
+        // Case: Event is ReceiverBindingEvent
+        // Description: Request to bind a Receiver to this Scheduler Subsystem
+        else if (event instanceof ReceiverBindingEvent rbEvent) {
+            // Next State: BindingReceiverState
+            // Required Constructor Arguments: NA
+            context.setNextState(new BindingReceiverState(context));
+            /* STATE LOGIC - MOVE TO STATE */ 
+            //System.out.println("Bound with: " + rbEvent);
+            //Class<? extends Subsystem> subsystemType = rbEvent.subsystemType();
+            //if (subsystemType.equals(Elevator.class)) {
+            //    transmitterToElevator.addReceiver(rbEvent.receiver());
+            //} else if (subsystemType.equals(Floor.class)) {
+            //    transmitterToFloor.addReceiver(rbEvent.receiver());
+            //} else
+            //    throw new InvalidTypeException("Unknown subsystem (" + subsystemType +
+            //            ") attempted to bind to scheduler.");
+        }
+        else {
+            InvalidTypeException e = new InvalidTypeException("Event type received cannot be handled by this subsystem.");
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    /**
+     * Exit activities for this state.
+     */
+    @Override
+    public void exit() {
+        // Only do this here if exit activities affect next state selection.
+        //context.setNextState(new ReceivingState(context));
+    }
+
+}
+
+

--- a/src/Subsystem/SchedulerSubsystem/ReceivingState.java
+++ b/src/Subsystem/SchedulerSubsystem/ReceivingState.java
@@ -72,8 +72,6 @@ public class ReceivingState extends State {
             // Next State: StoringFloorRequestState
             // Required Constructor Arguments: context
             context.setNextState(new StoringFloorRequestState(context, frEvent)); 
-            // CHEAT CODE: Back to ReceivingState for now
-            //context.setNextState(new ReceivingState(context)); 
         }
         // Case: Event is PassengerLoadEvent
         // Description: Notification from Floor of Passengers requiring load
@@ -82,8 +80,6 @@ public class ReceivingState extends State {
             // Next State: LoadingPassengerState
             // Required Constructor Arguments: PassengerLoadEvent
             context.setNextState(new LoadingPassengerState(context, plEvent));
-            // CHEAT CODE: Back to ReceivingState for now
-            //context.setNextState(new ReceivingState(context)); 
         } 
         // Case: Event is ReceiverBindingEvent
         // Description: Request to bind a Receiver to this Scheduler Subsystem
@@ -92,8 +88,6 @@ public class ReceivingState extends State {
             // Next State: BindingReceiverState
             // Required Constructor Arguments: ReceiverBindingEvent
             context.setNextState(new BindingReceiverState(context, rbEvent));
-            // CHEAT CODE: Back to ReceivingState for now
-            //context.setNextState(new ReceivingState(context)); 
         }
         else {
             InvalidTypeException e = new InvalidTypeException("Event type received cannot be handled by this subsystem.");

--- a/src/Subsystem/SchedulerSubsystem/ReceivingState.java
+++ b/src/Subsystem/SchedulerSubsystem/ReceivingState.java
@@ -62,7 +62,7 @@ public class ReceivingState extends State {
             // Next State: StoringFloorRequestState
             // Required Constructor Arguments: NA
             //context.setNextState(new StoringFloorRequestState(context)); 
-            // CHEAT CODE: Back to RecevingState for now
+            // CHEAT CODE: Back to ReceivingState for now
             context.setNextState(new ReceivingState(context)); 
         }
         // Case: Event is PassengerLoadEvent
@@ -72,7 +72,7 @@ public class ReceivingState extends State {
             // Next State: LoadingPassengerState
             // Required Constructor Arguments: NA
             //context.setNextState(new LoadingPassengerState(context));
-            // CHEAT CODE: Back to RecevingState for now
+            // CHEAT CODE: Back to ReceivingState for now
             context.setNextState(new ReceivingState(context)); 
 
             /* STATE LOGIC - MOVE TO STATE */ 
@@ -87,7 +87,7 @@ public class ReceivingState extends State {
             // Next State: BindingReceiverState
             // Required Constructor Arguments: NA
             //context.setNextState(new BindingReceiverState(context));
-            // CHEAT CODE: Back to RecevingState for now
+            // CHEAT CODE: Back to ReceivingState for now
             context.setNextState(new ReceivingState(context)); 
             /* STATE LOGIC - MOVE TO STATE */ 
             //System.out.println("Bound with: " + rbEvent);

--- a/src/Subsystem/SchedulerSubsystem/ReceivingState.java
+++ b/src/Subsystem/SchedulerSubsystem/ReceivingState.java
@@ -15,7 +15,8 @@ import com.sun.jdi.InvalidTypeException;
  * Class which models the Receiving State of the Scheduler FSM.
  *
  * Responsibilities:
- * - 
+ * - Receive a SystemMessage event from the Scheduler's Receiver
+ * - Point to the appropriate next state and pass it the received event
  *
  * @author AA/MD
  * @version Iteration-3

--- a/src/Subsystem/SchedulerSubsystem/ReceivingState.java
+++ b/src/Subsystem/SchedulerSubsystem/ReceivingState.java
@@ -80,20 +80,10 @@ public class ReceivingState extends State {
         else if (event instanceof ReceiverBindingEvent rbEvent) {
             System.out.println("*** Scheduler:ReceivingState:Entry: Received ReceiverBindingEvent.");
             // Next State: BindingReceiverState
-            // Required Constructor Arguments: NA
-            //context.setNextState(new BindingReceiverState(context));
+            // Required Constructor Arguments: ReceiverBindingEvent
+            context.setNextState(new BindingReceiverState(context, rbEvent));
             // CHEAT CODE: Back to ReceivingState for now
-            context.setNextState(new ReceivingState(context)); 
-            /* STATE LOGIC - MOVE TO STATE */ 
-            //System.out.println("Bound with: " + rbEvent);
-            //Class<? extends Subsystem> subsystemType = rbEvent.subsystemType();
-            //if (subsystemType.equals(Elevator.class)) {
-            //    transmitterToElevator.addReceiver(rbEvent.receiver());
-            //} else if (subsystemType.equals(Floor.class)) {
-            //    transmitterToFloor.addReceiver(rbEvent.receiver());
-            //} else
-            //    throw new InvalidTypeException("Unknown subsystem (" + subsystemType +
-            //            ") attempted to bind to scheduler.");
+            //context.setNextState(new ReceivingState(context)); 
         }
         else {
             InvalidTypeException e = new InvalidTypeException("Event type received cannot be handled by this subsystem.");

--- a/src/Subsystem/SchedulerSubsystem/ReceivingState.java
+++ b/src/Subsystem/SchedulerSubsystem/ReceivingState.java
@@ -1,6 +1,9 @@
 package Subsystem.SchedulerSubsystem;
 
 import Messaging.Messages.Events.ElevatorStateEvent;
+import Messaging.Messages.Events.FloorRequestEvent;
+import Messaging.Messages.Events.PassengerLoadEvent;
+import Messaging.Messages.Events.ReceiverBindingEvent;
 import Messaging.Messages.SystemMessage;
 import StatePatternLib.Context;
 import StatePatternLib.State;
@@ -28,12 +31,12 @@ public class ReceivingState extends State {
      */
     @Override
     public void entry() {
-        // DEBUG
-        System.out.println("\nElevator State: Entering RECEIVING State\n");
+        System.out.println("*** Scheduler:ReceivingState:Entry");
         // Get the SystemMessage (pop from Receiver buffer)
         event = ((Scheduler) context).receive();
     }
 
+    
     /**
      * Do activities for this state.
      *
@@ -42,27 +45,35 @@ public class ReceivingState extends State {
      */
     @Override
     public void doActivity() {
+        System.out.println("*** Scheduler:ReceivingState:Do");
 
         // Case: Event is ElevatorStateEvent
         // Description: Notification from Elevator conveying its state
         if (event instanceof ElevatorStateEvent esEvent) {
+            System.out.println("*** Scheduler:ReceivingState:Entry: Received ElevatorStateEvent.");
             // Next State: ProcessingElevatorEventState
             // Required Constructor Arguments: NA
-            context.setNextState(new ProcessingElevatorEventState(context)); 
+            context.setNextState(new ProcessingElevatorEventState(context, esEvent)); 
         }
         // Case: Event is FloorRequestEvent
         // Description: Request from Floor asking for service
         else if (event instanceof FloorRequestEvent frEvent) {
+            System.out.println("*** Scheduler:ReceivingState:Entry: Received FloorRequestEvent.");
             // Next State: StoringFloorRequestState
             // Required Constructor Arguments: NA
-            context.setNextState(new StoringFloorRequestState(context)); 
+            //context.setNextState(new StoringFloorRequestState(context)); 
+            // CHEAT CODE: Back to RecevingState for now
+            context.setNextState(new ReceivingState(context)); 
         }
         // Case: Event is PassengerLoadEvent
         // Description: Notification from Floor of Passengers requiring load
         else if (event instanceof PassengerLoadEvent plEvent) {
+            System.out.println("*** Scheduler:ReceivingState:Entry: Received PassengerLoadEvent.");
             // Next State: LoadingPassengerState
             // Required Constructor Arguments: NA
-            context.setNextState(new LoadingPassengerState(context));
+            //context.setNextState(new LoadingPassengerState(context));
+            // CHEAT CODE: Back to RecevingState for now
+            context.setNextState(new ReceivingState(context)); 
 
             /* STATE LOGIC - MOVE TO STATE */ 
             //transmitterToElevator.send(new MovePassengersCommand(plEvent.elevNumber(), plEvent.passengers())); // put inside state
@@ -72,9 +83,12 @@ public class ReceivingState extends State {
         // Case: Event is ReceiverBindingEvent
         // Description: Request to bind a Receiver to this Scheduler Subsystem
         else if (event instanceof ReceiverBindingEvent rbEvent) {
+            System.out.println("*** Scheduler:ReceivingState:Entry: Received ReceiverBindingEvent.");
             // Next State: BindingReceiverState
             // Required Constructor Arguments: NA
-            context.setNextState(new BindingReceiverState(context));
+            //context.setNextState(new BindingReceiverState(context));
+            // CHEAT CODE: Back to RecevingState for now
+            context.setNextState(new ReceivingState(context)); 
             /* STATE LOGIC - MOVE TO STATE */ 
             //System.out.println("Bound with: " + rbEvent);
             //Class<? extends Subsystem> subsystemType = rbEvent.subsystemType();
@@ -98,6 +112,7 @@ public class ReceivingState extends State {
      */
     @Override
     public void exit() {
+        System.out.println("*** Scheduler:ReceivingState:Exit\n");
         // Only do this here if exit activities affect next state selection.
         //context.setNextState(new ReceivingState(context));
     }

--- a/src/Subsystem/SchedulerSubsystem/Scheduler.java
+++ b/src/Subsystem/SchedulerSubsystem/Scheduler.java
@@ -7,6 +7,7 @@ import Messaging.Messages.Events.ElevatorStateEvent;
 import Messaging.Messages.Events.FloorRequestEvent;
 import Messaging.Messages.SystemMessage;
 import Messaging.Transceivers.Receivers.Receiver;
+import Messaging.Transceivers.Receivers.SerializableReceiver;
 import Messaging.Transceivers.Transmitters.Transmitter;
 import StatePatternLib.Context;
 import Subsystem.ElevatorSubsytem.ElevatorUtilities;
@@ -75,7 +76,7 @@ public class Scheduler extends Context implements Subsystem {
      *
      * @param receiver The Receiver to bind.
      */
-    void bindElevatorReceiver(Receiver receiver) {
+    void bindElevatorReceiver(SerializableReceiver receiver) {
         transmitterToElevator.addReceiver(receiver);
     }
 
@@ -84,7 +85,7 @@ public class Scheduler extends Context implements Subsystem {
      *
      * @param receiver The Receiver to bind.
      */
-    void bindFloorReceiver(Receiver receiver) {
+    void bindFloorReceiver(SerializableReceiver receiver) {
         transmitterToFloor.addReceiver(receiver);
     }
 

--- a/src/Subsystem/SchedulerSubsystem/Scheduler.java
+++ b/src/Subsystem/SchedulerSubsystem/Scheduler.java
@@ -3,6 +3,7 @@ package Subsystem.SchedulerSubsystem;
 import Messaging.Messages.Commands.MoveElevatorCommand;
 import Messaging.Messages.Commands.MovePassengersCommand;
 import Messaging.Messages.Commands.SendPassengersCommand;
+import Messaging.Messages.Commands.SystemCommand;
 import Messaging.Messages.Direction;
 import Messaging.Messages.Events.*;
 import Messaging.Messages.SystemMessage;
@@ -24,8 +25,8 @@ import java.util.*;
  */
 public class Scheduler extends Context implements Runnable, Subsystem {
     // TODO: Make fields private again, make access methods for subclasses instead
-    protected final Transmitter<? extends Receiver> transmitterToFloor;
-    protected final Transmitter<? extends Receiver> transmitterToElevator;
+    private final Transmitter<? extends Receiver> transmitterToFloor;
+    private final Transmitter<? extends Receiver> transmitterToElevator;
     private final Receiver receiver;
     protected final Map<DestinationEvent, Long> floorRequestsToTime;
     private final ArrayList<ElevatorStateEvent> idleElevators;
@@ -58,6 +59,42 @@ public class Scheduler extends Context implements Runnable, Subsystem {
 //        if (!idleElevators.isEmpty()){
 //            processElevatorEvent(idleElevators.remove(0));
 //        }
+    }
+
+    /**
+     * Bind Receiver to this Scheduler's Transmitter to Elevator.
+     *
+     * @param receiver The Receiver to bind.
+     */
+    void bindElevatorReceiver(Receiver receiver) {
+        transmitterToElevator.addReceiver(receiver);
+    }
+
+    /**
+     * Bind Receiver to this Scheduler's Transmitter to Floor.
+     *
+     * @param receiver The Receiver to bind.
+     */
+    void bindFloorReceiver(Receiver receiver) {
+        transmitterToFloor.addReceiver(receiver);
+    }
+
+    /**
+     * Transmit a SystemCommand to an Floor using this Scheduler's Transmitter.
+     *
+     * @param command The SystemCommand to send to the Floor.
+     */
+    void transmitToFloor(SystemCommand command) {
+        transmitterToFloor.send(command);
+    }
+
+    /**
+     * Transmit a SystemCommand to an Elevator using this Scheduler's Transmitter.
+     *
+     * @param command The SystemCommand to send to the Elevator.
+     */
+    void transmitToElevator(SystemCommand command) {
+        transmitterToElevator.send(command);
     }
 
     /**

--- a/src/Subsystem/SchedulerSubsystem/Scheduler.java
+++ b/src/Subsystem/SchedulerSubsystem/Scheduler.java
@@ -19,7 +19,7 @@ import java.util.*;
  *
  * @version Iteration-3
  */
-public class Scheduler extends Context implements Runnable, Subsystem {
+public class Scheduler extends Context implements Subsystem {
     private final Transmitter<? extends Receiver> transmitterToFloor;
     private final Transmitter<? extends Receiver> transmitterToElevator;
     private final Receiver receiver;

--- a/src/Subsystem/SchedulerSubsystem/Scheduler.java
+++ b/src/Subsystem/SchedulerSubsystem/Scheduler.java
@@ -28,7 +28,7 @@ public class Scheduler extends Context implements Runnable, Subsystem {
     protected final Transmitter<? extends Receiver> transmitterToElevator;
     private final Receiver receiver;
     protected final Map<DestinationEvent, Long> floorRequestsToTime;
-    protected final ArrayList<ElevatorStateEvent> idleElevators;
+    private final ArrayList<ElevatorStateEvent> idleElevators;
 
     public Scheduler(Receiver receiver,
                      Transmitter<? extends Receiver> transmitterToFloor,
@@ -54,10 +54,39 @@ public class Scheduler extends Context implements Runnable, Subsystem {
         if (!floorRequestsToTime.containsKey(event.destinationEvent()))
             // Only store request if it does not already exist
             floorRequestsToTime.put(event.destinationEvent(), event.time());
-        if (!idleElevators.isEmpty()){
-            processElevatorEvent(idleElevators.remove(0));
-        }
+          // Relegate to StoringFloorRequestState
+//        if (!idleElevators.isEmpty()){
+//            processElevatorEvent(idleElevators.remove(0));
+//        }
     }
+
+    /**
+     * Query if there are idle elevators.
+     *
+     * @return true if there are idle Elevators; false otherwise.
+     */
+    boolean areIdleElevators() {
+        return !idleElevators.isEmpty();
+    }
+
+    /**
+     * Get first idle elevator.
+     *
+     * @return ElevatorStateEvent corresponding to first idle Elevator.
+     */
+    ElevatorStateEvent getFirstIdleElevator() {
+        return idleElevators.remove(0);
+    }
+
+    /**
+     * Register an Elevator as idle by passing its ElevatorStateEvent.
+     *
+     * @param event The idle ElevatorStateEvent to store.
+     */
+    void addIdleElevator(ElevatorStateEvent event) {
+       idleElevators.add(event);
+    }
+
     /**
      * Returns true if elevator should stop, false otherwise.
      *

--- a/src/Subsystem/SchedulerSubsystem/Scheduler.java
+++ b/src/Subsystem/SchedulerSubsystem/Scheduler.java
@@ -23,8 +23,9 @@ import java.util.*;
  * @version Iteration-2
  */
 public class Scheduler extends Context implements Runnable, Subsystem {
-    private final Transmitter<? extends Receiver> transmitterToFloor;
-    private final Transmitter<? extends Receiver> transmitterToElevator;
+    // TODO: Make fields private again, make access methods for subclasses instead
+    protected final Transmitter<? extends Receiver> transmitterToFloor;
+    protected final Transmitter<? extends Receiver> transmitterToElevator;
     private final Receiver receiver;
     protected final Map<DestinationEvent, Long> floorRequestsToTime;
     protected final ArrayList<ElevatorStateEvent> idleElevators;

--- a/src/Subsystem/SchedulerSubsystem/Scheduler.java
+++ b/src/Subsystem/SchedulerSubsystem/Scheduler.java
@@ -24,11 +24,10 @@ import java.util.*;
  * @version Iteration-2
  */
 public class Scheduler extends Context implements Runnable, Subsystem {
-    // TODO: Make fields private again, make access methods for subclasses instead
     private final Transmitter<? extends Receiver> transmitterToFloor;
     private final Transmitter<? extends Receiver> transmitterToElevator;
     private final Receiver receiver;
-    protected final Map<DestinationEvent, Long> floorRequestsToTime;
+    private final Map<DestinationEvent, Long> floorRequestsToTime;
     private final ArrayList<ElevatorStateEvent> idleElevators;
 
     public Scheduler(Receiver receiver,
@@ -42,6 +41,24 @@ public class Scheduler extends Context implements Runnable, Subsystem {
 
         // Initialize first state for this Subsystem's State Machine
         setNextState(new ReceivingState(this));
+    }
+
+    /**
+     * Remove a DestinationEvent from this Scheduler after service.
+     *
+     * @param event The DestinationEvent to remove.
+     */
+    void removeDestinationEvent(DestinationEvent event) {
+        floorRequestsToTime.remove(event);
+    }
+
+    /**
+     * Check if the Scheduler has any pending DestinationEvents.
+     *
+     * @ return true if there are pending DestinationEvents; false otherwise.
+     */
+    boolean hasPendingDestinationEvents() {
+        return !floorRequestsToTime.isEmpty();
     }
 
     /**

--- a/src/Subsystem/SchedulerSubsystem/StoringFloorRequestState.java
+++ b/src/Subsystem/SchedulerSubsystem/StoringFloorRequestState.java
@@ -34,7 +34,7 @@ public class StoringFloorRequestState extends State {
      */
     @Override
     public void entry() {
-        System.out.println("*** Scheduler:StoringFloorRequestState:Entry");
+        System.out.println("[INFO::FSM] Scheduler:StoringFloorRequestState:Entry");
     }
 
     /**
@@ -45,7 +45,7 @@ public class StoringFloorRequestState extends State {
      */
     @Override
     public void doActivity() {
-        System.out.println("*** Scheduler:StoringFloorRequestState:Do");
+        System.out.println("[INFO::FSM] Scheduler:StoringFloorRequestState:Do");
 
         // Store the FloorRequestEvent
         ((Scheduler)context).storeFloorRequest(event);
@@ -63,7 +63,7 @@ public class StoringFloorRequestState extends State {
         // Description: No Elevator is immediately available for work.
         else {
             // Next State: ReceivingState
-            // Required Constructor Arguments: NA
+            // Required Constructor Arguments: context
             context.setNextState(new ReceivingState(context)); 
         }
 
@@ -74,7 +74,7 @@ public class StoringFloorRequestState extends State {
      */
     @Override
     public void exit() {
-        System.out.println("*** Scheduler:StoringFloorRequestState:Exit");
+        System.out.println("[INFO::FSM] Scheduler:StoringFloorRequestState:Exit");
         // Only do this here if exit activities affect next state selection.
         //context.setNextState(new StoringFloorRequestState(context));
     }

--- a/src/Subsystem/SchedulerSubsystem/StoringFloorRequestState.java
+++ b/src/Subsystem/SchedulerSubsystem/StoringFloorRequestState.java
@@ -63,7 +63,6 @@ public class StoringFloorRequestState extends State {
 
         // Case: There are idle Elevators.
         // Description: An Elevator is immediately available for work.
-        // TODO: Replace with Scheduler method call, when implemented
         if (((Scheduler)context).areIdleElevators()) {
             // Next State: ProcessingElevatorEventState
             // Required Constructor Arguments: ElevatorStateEvent

--- a/src/Subsystem/SchedulerSubsystem/StoringFloorRequestState.java
+++ b/src/Subsystem/SchedulerSubsystem/StoringFloorRequestState.java
@@ -10,6 +10,18 @@ import StatePatternLib.Context;
 import StatePatternLib.State;
 import com.sun.jdi.InvalidTypeException;
 
+/**
+ * Scheduler FSM State: Storing Floor Request State.
+ *
+ * Class which models the Storing Floor Request State of the Scheduler FSM.
+ *
+ * Responsibilities:
+ * - Store a a request for floor service
+ * - If there are idle elevators, make them available for immediate service
+ *
+ * @author MD
+ * @version Iteration-3
+ */
 public class StoringFloorRequestState extends State {
 
     /* Instance Variables */
@@ -21,7 +33,6 @@ public class StoringFloorRequestState extends State {
      * Parametric constructor.
      *
      * @param context Context of state machine that this is a state of.
-     * @author MD
      */
     public StoringFloorRequestState(Context context, FloorRequestEvent event) {
         super(context);
@@ -75,10 +86,6 @@ public class StoringFloorRequestState extends State {
     @Override
     public void exit() {
         System.out.println("[INFO::FSM] Scheduler:StoringFloorRequestState:Exit");
-        // Only do this here if exit activities affect next state selection.
-        //context.setNextState(new StoringFloorRequestState(context));
     }
 
 }
-
-

--- a/src/Subsystem/SchedulerSubsystem/StoringFloorRequestState.java
+++ b/src/Subsystem/SchedulerSubsystem/StoringFloorRequestState.java
@@ -1,0 +1,84 @@
+package Subsystem.SchedulerSubsystem;
+
+import Messaging.Messages.Commands.MoveElevatorCommand;
+import Messaging.Messages.Events.DestinationEvent;
+import Messaging.Messages.Events.ElevatorStateEvent;
+import Messaging.Messages.Events.FloorRequestEvent;
+import Messaging.Messages.SystemMessage;
+import Messaging.Messages.Commands.SendPassengersCommand;
+import StatePatternLib.Context;
+import StatePatternLib.State;
+import com.sun.jdi.InvalidTypeException;
+
+public class StoringFloorRequestState extends State {
+
+    /* Instance Variables */
+    
+    // The FloorRequestEvent to process
+    private FloorRequestEvent event;
+
+    /**
+     * Parametric constructor.
+     *
+     * @param context Context of state machine that this is a state of.
+     * @author MD
+     */
+    public StoringFloorRequestState(Context context, FloorRequestEvent event) {
+        super(context);
+        // Initialize the ElevatorStateEvent that needs processing in this state.
+        this.event = event;
+    }
+
+    /**
+     * Entry activities for this state.
+     */
+    @Override
+    public void entry() {
+        System.out.println("*** Scheduler:StoringFloorRequestState:Entry");
+    }
+
+    /**
+     * Do activities for this state.
+     *
+     * In this state, we just store the FloorRequestEvent, and select next state
+     * based on if we have any idle Elevators.
+     */
+    @Override
+    public void doActivity() {
+        System.out.println("*** Scheduler:StoringFloorRequestState:Do");
+
+        // Store the FloorRequestEvent
+        ((Scheduler)context).storeFloorRequest(event);
+
+        // Case: There are idle Elevators.
+        // Description: An Elevator is immediately available for work.
+        // TODO: Replace with Scheduler method call, when implemented
+        if (((Scheduler)context).areIdleElevators()) {
+            // Next State: ProcessingElevatorEventState
+            // Required Constructor Arguments: ElevatorStateEvent
+            ElevatorStateEvent elevatorStateEvent = ((Scheduler)context).getFirstIdleElevator();
+            context.setNextState(new ProcessingElevatorEventState(context, elevatorStateEvent)); 
+        }
+        // Case: There are NO idle Elevators.
+        // Description: No Elevator is immediately available for work.
+        else {
+            // Next State: ReceivingState
+            // Required Constructor Arguments: NA
+            context.setNextState(new ReceivingState(context)); 
+        }
+
+    }
+
+    /**
+     * Exit activities for this state.
+     */
+    @Override
+    public void exit() {
+        System.out.println("*** Scheduler:StoringFloorRequestState:Exit");
+        // Only do this here if exit activities affect next state selection.
+        //context.setNextState(new StoringFloorRequestState(context));
+    }
+
+}
+
+


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] ✅ Test
- [X] 🧑‍💻 Refactor

## Description
Refactor of the Scheduler to adhere to State Pattern implementation.
* Created new Scheduler States:
1. BindingReceiverState.java   
2. ProcessingElevatorEventState.java
3. LoadingPassengerState.java 
4. ReceivingState.java 
5. StoringFloorRequestState.java
* Relocated logic from Scheduler context to its states, where applicable.
* Added minor utility functions (getters, setters, bool queries, etc.) to allow states to access context variables/methods.
* Added debug prints to trace FSM traversal (which we should remove, but want you guys to make sure things are running through correctly first).

Please review this and make sure I ain't broke it. Felt like a lot of change to make no change, so hopefully nothing changed.

## How to test
Run Main.main() and expect similar behaviour.

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: Refactor only. Retained tests pass.
- [ ] I need help with writing tests:

## Screenshots