### PR TITLE
Implement closest elevator selection from idle queue in the scheduler.

### DIFF
--- a/src/Subsystem/SchedulerSubsystem/Scheduler.java
+++ b/src/Subsystem/SchedulerSubsystem/Scheduler.java
@@ -15,6 +15,8 @@ import Subsystem.Subsystem;
 
 import java.util.*;
 
+import static java.lang.Math.abs;
+
 /**
  * Scheduler class which models a scheduler in the simulation.
  *
@@ -117,14 +119,39 @@ public class Scheduler extends Context implements Subsystem {
     }
 
     /**
-     * Get first idle elevator.
+     * Get the closest idle Elevator to an incoming FloorRequestEvent.
      *
-     * @return ElevatorStateEvent corresponding to first idle Elevator.
+     * @param floorRequestEvent The FloorRequestEvent used to determine the
+     * closest idle elevator to send.
+     *
+     * @return ElevatorStateEvent corresponding to closest idle Elevator.
      */
-    ElevatorStateEvent getFirstIdleElevator() {
-        return idleElevators.remove(0);
-    }
+    ElevatorStateEvent getClosestIdleElevator(FloorRequestEvent floorRequestEvent) {
 
+        // Convenience variable to extract and hold target floor
+        int targetFloor = floorRequestEvent.destinationEvent().destinationFloor();
+        // Distance tracker (in number of floors)
+        int distance = 0;
+        // Initialize variables for our sort algorithm using the first idle elevator
+        int closestIdleElevatorIndex = 0;
+        int closestDistance = abs(idleElevators.get(0).currentFloor()- targetFloor);
+
+        // Determine closest idle Elevator in idleElevators
+        // Start at 1 to save a loop, since we initialized using 0
+        for (int i = 1; i < idleElevators.size(); i++) {
+            distance = (abs(idleElevators.get(i).currentFloor() - targetFloor));
+            // Case: This Elevator is the new closest Elevator
+            if (distance < closestDistance) {
+                // Update closest distance to track new minimum
+                closestDistance = distance;
+                // Catch the idle Elevator index for later reference
+                closestIdleElevatorIndex = i;
+            }
+        }
+
+        // Return the closest idle Elevator
+        return idleElevators.remove(closestIdleElevatorIndex);
+    }
     /**
      * Register an Elevator as idle by passing its ElevatorStateEvent.
      *

--- a/src/Subsystem/SchedulerSubsystem/StoringFloorRequestState.java
+++ b/src/Subsystem/SchedulerSubsystem/StoringFloorRequestState.java
@@ -66,7 +66,7 @@ public class StoringFloorRequestState extends State {
         if (((Scheduler)context).areIdleElevators()) {
             // Next State: ProcessingElevatorEventState
             // Required Constructor Arguments: ElevatorStateEvent
-            ElevatorStateEvent elevatorStateEvent = ((Scheduler)context).getFirstIdleElevator();
+            ElevatorStateEvent elevatorStateEvent = ((Scheduler)context).getClosestIdleElevator(event);
             context.setNextState(new ProcessingElevatorEventState(context, elevatorStateEvent)); 
         }
         // Case: There are NO idle Elevators.

--- a/test/resources/scenario-3-idle-elevator-test.txt
+++ b/test/resources/scenario-3-idle-elevator-test.txt
@@ -1,0 +1,34 @@
+###############################################################################
+# scenario-3-idle-elevator-test.txt                                           #
+###############################################################################
+# Input file used to provide inputs to the system. This file is assumed to be #
+# well-formed and is NOT validated at runtime.                                #
+###############################################################################
+#   arrivalTime   |   sourceFloor   |    direction    |    destinationFloor   #
+# ----------------|-----------------|-----------------|---------------------- #
+#       int       |       int       |    Direction    |         int           #
+# ----------------|-----------------|-----------------|---------------------- #
+#   hh:mm:ss.mmm  |        n        |    Up | Down    |          n            #
+###############################################################################
+# Scenario Description                                                        #
+# --------------------                                                        #
+# This scenario tests the response behaviour of idle elevators. The goal is   #
+# to verify that, when there are mutliple idle elevators, only the closest    #
+# one moves to service an incoming request at a floor.                        #
+###############################################################################
+
+## Test Sequence: Test Idle Elevator Behaviour
+
+# Send all elevators up to high floors, with enough time between to ensure we
+# have 3 different elevators servicing the requests (and not 1 servicing all 3)
+
+09:05:22.000 1 Up 7
+09:05:32.000 1 Up 5
+09:05:42.000 1 Up 6
+
+# We wait a while to issue the next request to ensure all of them have arrived
+# at their destination floors and are idle.
+# Then, we place a request at floor 3, and expect whichever elevator is at
+# Floor 5 (the closest idle Elevator to Floor 3) to service this request.
+
+09:06:50.000 3 Up 4


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature 
- [x] 🐛 Bug Fix (maybe? wasn't really a bug...)
- [ ] 📝 Documentation Update
- [ ] ✅ Test
- [ ] 🧑‍💻 Refactor

## Description
* Add a simple sort to select the closest idle elevator to service a floor request that comes in when there are idle elevators.
* Add a  config file and scenario file to test this.

## How to test
* Configure system to use `scenario-3-idle-elevator-test.txt` and `system-config-01.json`, run main(), inspect output.

## Added/updated tests?

- [x] Yes: Just a scenario test and a config for it.
- [ ] No, and this is why:
- [ ] I need help with writing tests:.

## Screenshots

## Notes
Branched this one off of `develop/scheduler-state-pattern`, so merge that guy before reviewing this one!