### PR TITLE
Implement Logger to Clean up Output

### DIFF
--- a/res/system-config-00.json
+++ b/res/system-config-00.json
@@ -1,4 +1,5 @@
 {
+  "verbosity": 1,
   "numFloors": 8,
   "numElevators": 1,
   "travelTime": 8500,

--- a/src/Configuration/Config.java
+++ b/src/Configuration/Config.java
@@ -10,6 +10,7 @@ package Configuration;
 public class Config {
 
     /* Instance Variables */
+    private final int verbosity;
     private final int numFloors;
     private final int numElevators;
     private final long travelTime;
@@ -21,6 +22,7 @@ public class Config {
      * Default constructor for class Config.
      */
     public Config() {
+        this.verbosity = 0;
         this.numFloors = 0;
         this.numElevators = 0;
         this.travelTime = 0;
@@ -28,6 +30,10 @@ public class Config {
     }
 
     /* Methods */
+
+    public int getVerbosity() {
+        return verbosity;
+    }
 
     public int getNumFloors() {
         return numFloors;
@@ -47,6 +53,7 @@ public class Config {
 
     public void printConfig() {
         System.out.println("Launching system under the following configuration:");
+        System.out.println("-- verbosity: " + getVerbosity());
         System.out.println("-- numFloors: " + getNumFloors());
         System.out.println("-- numElevators: " + getNumElevators());
         System.out.println("-- travelTime: " + getTravelTime() + " [ms]");

--- a/src/Mains/MainCombinedDMA.java
+++ b/src/Mains/MainCombinedDMA.java
@@ -31,7 +31,7 @@ public class MainCombinedDMA {
         TransceiverFactory dmaFactory = new TransceiverDMAFactory();
 
         // 3. Create and start Subsystem threads
-        Scheduler scheduler = new Scheduler(dmaFactory.createServerReceiver(),
+        Scheduler scheduler = new Scheduler(config, dmaFactory.createServerReceiver(),
                 dmaFactory.createServerTransmitter(),
                 dmaFactory.createServerTransmitter());
         Thread schedulerThread = new Thread(scheduler);

--- a/src/Mains/MainCombinedDMA.java
+++ b/src/Mains/MainCombinedDMA.java
@@ -43,7 +43,7 @@ public class MainCombinedDMA {
                     dmaFactory.createClientTransmitter())).start();
         }
         for (int i = 0; i < config.getNumElevators(); ++i) {
-            new Thread(new Elevator(i, dmaFactory.createClientReceiver(i),
+            new Thread(new Elevator(config, i, dmaFactory.createClientReceiver(i),
                     dmaFactory.createClientTransmitter())).start();
         }
 

--- a/src/Mains/MainElevatorUDP.java
+++ b/src/Mains/MainElevatorUDP.java
@@ -15,7 +15,7 @@ public class MainElevatorUDP {
      */
     public static void main(String[] args) {
         // 1. Configure system from JSON
-        System.out.println("\n****** Configuring System ******\n");
+        System.out.println("\n****** Configuring Elevators ******\n");
         Config config = (new Configurator().getConfig());
         config.printConfig();
 

--- a/src/Mains/MainElevatorUDP.java
+++ b/src/Mains/MainElevatorUDP.java
@@ -24,7 +24,7 @@ public class MainElevatorUDP {
 
         // 3. Create and start elevator threads
         for (int i = 0; i < config.getNumElevators(); ++i) {
-            new Thread(new Elevator(i, udpFactory.createClientReceiver(i),
+            new Thread(new Elevator(config, i, udpFactory.createClientReceiver(i),
                     udpFactory.createClientTransmitter())).start();
         }
     }

--- a/src/Mains/MainSchedulerUDP.java
+++ b/src/Mains/MainSchedulerUDP.java
@@ -17,7 +17,9 @@ public class MainSchedulerUDP {
         TransceiverFactory transceiverFactory = new TransceiverUDPFactory();
 
         // 2. Get Config
+        System.out.println("\n****** Configuring Scheduler ******\n");
         Config config = (new Configurator().getConfig());
+        config.printConfig();
 
         // 3. Create and start scheduler
         Scheduler scheduler = new Scheduler(config,

--- a/src/Mains/MainSchedulerUDP.java
+++ b/src/Mains/MainSchedulerUDP.java
@@ -1,5 +1,7 @@
 package Mains;
 
+import Configuration.Config;
+import Configuration.Configurator;
 import Messaging.Transceivers.TransceiverFactory;
 import Messaging.Transceivers.TransceiverUDPFactory;
 import Subsystem.SchedulerSubsystem.Scheduler;
@@ -14,8 +16,12 @@ public class MainSchedulerUDP {
         // 1. Create transceiver factory
         TransceiverFactory transceiverFactory = new TransceiverUDPFactory();
 
-        // 2. Create and start scheduler
-        Scheduler scheduler = new Scheduler(transceiverFactory.createServerReceiver(),
+        // 2. Get Config
+        Config config = (new Configurator().getConfig());
+
+        // 3. Create and start scheduler
+        Scheduler scheduler = new Scheduler(config,
+                transceiverFactory.createServerReceiver(),
                 transceiverFactory.createServerTransmitter(),
                 transceiverFactory.createServerTransmitter());
         new Thread(scheduler).start();

--- a/src/Subsystem/ElevatorSubsytem/LoadingState.java
+++ b/src/Subsystem/ElevatorSubsytem/LoadingState.java
@@ -20,7 +20,8 @@ public class LoadingState extends State {
 
     @Override
     public void entry() {
-        System.out.println("LOADING STATE");
+        String msg = "LoadingState:Entry";
+        ((Elevator)context).logger.log(Logging.Logger.LEVEL.DEBUG, ((Elevator)context).logId, msg);
         ((Elevator) context).unload();
     }
     @Override

--- a/src/Subsystem/ElevatorSubsytem/MovingState.java
+++ b/src/Subsystem/ElevatorSubsytem/MovingState.java
@@ -19,7 +19,8 @@ public class MovingState extends State {
 
     @Override
     public void entry() {
-        System.out.println("MOVING STATE");
+        String msg = "MovingState:Entry";
+        ((Elevator)context).logger.log(Logging.Logger.LEVEL.DEBUG, ((Elevator)context).logId, msg);
     }
 
     @Override

--- a/src/Subsystem/ElevatorSubsytem/ReceivingState.java
+++ b/src/Subsystem/ElevatorSubsytem/ReceivingState.java
@@ -22,10 +22,14 @@ public class ReceivingState extends State {
 
     @Override
     public void entry() {
-        System.out.println("RECEIVING STATE");
+        String msg = "ReceivingState:Entry";
+        ((Elevator)context).logger.log(Logging.Logger.LEVEL.DEBUG, ((Elevator)context).logId, msg);
+
         ((Elevator) context).sendStateUpdate();
         event = ((Elevator) context).receive();
-        System.out.println("received event: "+ event);
+
+        msg = "Received event: " + event;
+        ((Elevator)context).logger.log(Logging.Logger.LEVEL.DEBUG, ((Elevator)context).logId, msg);
     }
 
     @Override

--- a/src/Subsystem/Logging/Logger.java
+++ b/src/Subsystem/Logging/Logger.java
@@ -1,0 +1,64 @@
+package Logging;
+
+/**
+ *  Logger class which handles system logging via console print to `stdout`.
+ *
+ * @author M. Desantis
+ * @version Iteration-3
+ */
+public class Logger {
+
+    /* Enums */
+    public enum LEVEL {
+        INFO,  // INFO level messages for general prints
+        DEBUG  // DEBUG level messages for additional debug prints
+    }
+
+    /* Instance Variables */
+    private final int verbosity;
+
+    /* Constructors */
+
+    /**
+     * Default constructor for class Logger.
+     *
+     * @param verbosity The verbosity level, which should be set in 
+     * the system configuration JSON and supplied here. 
+     *   0: indicates no messages should be logged (suppress output)
+     *   1: indicates only INFO level messages should be logged
+     *   2: indicates INFO and DEBUG messages should be logged
+     */
+    public Logger(int verbosity) {
+        this.verbosity = verbosity;
+    }
+
+    /* Methods */
+
+    /**
+     * Log a message by printing to console, specifying the log level, the 
+     * identifier of the message source, and the message.
+     *
+     * @param level Log level: [Logger.INFO | Logger.DEBUG]
+     * @param logId Log ID for message source (eg. "Elevator 1")
+     * @param message Message to log
+     *
+     */
+    public void log(Logger.LEVEL level, String logId, String message) {
+
+        // The prefix for this message
+        String prefix = "[" + level + "::" + logId + "] ";
+
+        // Case: Print INFO level messages only
+        //if ((verbosity == 1) && (level == Logger.LEVEL.INFO)) {
+        if (verbosity > 0) {
+            // Case: Print INFO level messages only
+            if (level == Logger.LEVEL.INFO) {
+                System.out.println(prefix + message);
+            }
+            if ((verbosity == 2) && (level == Logger.LEVEL.DEBUG)) {
+                System.out.println(prefix + message);
+            }
+        }
+    }
+
+}

--- a/src/Subsystem/SchedulerSubsystem/BindingReceiverState.java
+++ b/src/Subsystem/SchedulerSubsystem/BindingReceiverState.java
@@ -50,26 +50,27 @@ public class BindingReceiverState extends State {
      */
     @Override
     public void entry() {
-        System.out.println("[INFO::FSM] Scheduler:BindingReceiverState:Entry");
+        String msg = "BindingReceiverState:Entry";
+        ((Scheduler)context).logger.log(Logging.Logger.LEVEL.DEBUG, ((Scheduler)context).logId, msg);
 
-            Class<? extends Subsystem> subsystemType = event.subsystemType();
+        Class<? extends Subsystem> subsystemType = event.subsystemType();
 
-            // Case: Subsystem is Elevator
-            if (subsystemType.equals(Elevator.class)) {
-                ((Scheduler)context).bindElevatorReceiver(event.receiver());
-            } 
-            // Case: Subsystem is Floor
-            else if (subsystemType.equals(Floor.class)) {
-                ((Scheduler)context).bindFloorReceiver(event.receiver());
-            } 
-            // Case: Subsystem is BAD
-            else {
-                try {
-                    throw new InvalidTypeException("Unknown subsystem (" + subsystemType + ") attempted to bind to scheduler.");
-                } catch (InvalidTypeException e) {
-                    throw new RuntimeException(e);
-                }
+        // Case: Subsystem is Elevator
+        if (subsystemType.equals(Elevator.class)) {
+            ((Scheduler)context).bindElevatorReceiver(event.receiver());
+        } 
+        // Case: Subsystem is Floor
+        else if (subsystemType.equals(Floor.class)) {
+            ((Scheduler)context).bindFloorReceiver(event.receiver());
+        } 
+        // Case: Subsystem is BAD
+        else {
+            try {
+                throw new InvalidTypeException("Unknown subsystem (" + subsystemType + ") attempted to bind to scheduler.");
+            } catch (InvalidTypeException e) {
+                throw new RuntimeException(e);
             }
+        }
     }
 
     /**
@@ -78,7 +79,6 @@ public class BindingReceiverState extends State {
      */
     @Override
     public void doActivity() {
-        System.out.println("[INFO::FSM] Scheduler:BindingReceiverState:Do");
     }
 
     /**
@@ -86,7 +86,6 @@ public class BindingReceiverState extends State {
      */
     @Override
     public void exit() {
-        System.out.println("[INFO::FSM] Scheduler:BindingReceiverState:Exit");
         // Next State: BindingReceiverState
         // Required Constructor Arguments: context
         context.setNextState(new ReceivingState(context));

--- a/src/Subsystem/SchedulerSubsystem/LoadingPassengerState.java
+++ b/src/Subsystem/SchedulerSubsystem/LoadingPassengerState.java
@@ -47,7 +47,8 @@ public class LoadingPassengerState extends State {
      */
     @Override
     public void entry() {
-        System.out.println("[INFO::FSM] Scheduler:LoadingPassengerState:Entry");
+        String msg = "LoadingPassengerState:Entry";
+        ((Scheduler)context).logger.log(Logging.Logger.LEVEL.DEBUG, ((Scheduler)context).logId, msg);
     }
 
     /**
@@ -58,8 +59,6 @@ public class LoadingPassengerState extends State {
      */
     @Override
     public void doActivity() {
-        System.out.println("[INFO::FSM] Scheduler:LoadingPassengerState:Do");
-
         // Load Passengers, notify Elevator
         MovePassengersCommand movePassengersCommand = new MovePassengersCommand(event.elevNumber(), event.passengers());
         ((Scheduler)context).transmitToElevator(movePassengersCommand);
@@ -70,7 +69,6 @@ public class LoadingPassengerState extends State {
      */
     @Override
     public void exit() {
-        System.out.println("[INFO::FSM] Scheduler:LoadingPassengerState:Exit");
         // Next State: ReceivingState
         // Required Constructor Arguments: context
         context.setNextState(new ReceivingState(context));

--- a/src/Subsystem/SchedulerSubsystem/ProcessingElevatorEventState.java
+++ b/src/Subsystem/SchedulerSubsystem/ProcessingElevatorEventState.java
@@ -46,7 +46,8 @@ public class ProcessingElevatorEventState extends State {
      */
     @Override
     public void entry() {
-        System.out.println("[INFO::FSM] Scheduler:ProcessingElevatorEventState:Entry");
+        String msg = "ProcessingElevatorEventState:Entry";
+        ((Scheduler)context).logger.log(Logging.Logger.LEVEL.DEBUG, ((Scheduler)context).logId, msg);
     }
 
     /**
@@ -58,14 +59,13 @@ public class ProcessingElevatorEventState extends State {
      */
     @Override
     public void doActivity() {
-        System.out.println("[INFO::FSM] Scheduler:ProcessingElevatorEventState:Do");
-
         // Case: Elevator indicates it is Idle.
         // Description: Elevator has neither Floors nor Passengers to service, and is
         //              not in motion. It's just chillin'.
         if (!((Scheduler)context).hasPendingDestinationEvents() && event.passengerCountMap().isEmpty()) {
 
-            System.out.printf("Scheduler: Elevator %s idle%n", event.elevatorNum());
+            String msg = "Elevator " + event.elevatorNum() + " is idle.";
+            ((Scheduler)context).logger.log(Logging.Logger.LEVEL.DEBUG, ((Scheduler)context).logId, msg);
 
             // Register this Elevator as Idle
             ((Scheduler)context).addIdleElevator(event);
@@ -77,7 +77,9 @@ public class ProcessingElevatorEventState extends State {
         // Case: Elevator indicates it is Stopping.
         // Description: Since the Elevator is stopping, it must be servicing this Floor.
         else if (((Scheduler)context).isElevatorStopping(event)) { 
-            System.out.printf("Elevator %s stopped.%n", event.elevatorNum());
+
+            String msg = "Elevator " + event.elevatorNum() + " has stopped.";
+            ((Scheduler)context).logger.log(Logging.Logger.LEVEL.DEBUG, ((Scheduler)context).logId, msg);
 
             // Notify Floor for service
             ((Scheduler)context).transmitToFloor(new SendPassengersCommand(event.currentFloor(), event.elevatorNum(), ((Scheduler)context).getElevatorDirection(event)));
@@ -109,7 +111,6 @@ public class ProcessingElevatorEventState extends State {
      */
     @Override
     public void exit() {
-        System.out.println("[INFO::FSM] Scheduler:ProcessingElevatorEventState:Exit");
     }
 
 }

--- a/src/Subsystem/SchedulerSubsystem/ReceivingState.java
+++ b/src/Subsystem/SchedulerSubsystem/ReceivingState.java
@@ -42,7 +42,8 @@ public class ReceivingState extends State {
      */
     @Override
     public void entry() {
-        System.out.println("[INFO::FSM] Scheduler:ReceivingState:Entry");
+        String msg = "ReceivingState:Entry";
+        ((Scheduler)context).logger.log(Logging.Logger.LEVEL.DEBUG, ((Scheduler)context).logId, msg);
         // Get the SystemMessage (pop from Receiver buffer)
         event = ((Scheduler) context).receive();
     }
@@ -56,12 +57,14 @@ public class ReceivingState extends State {
      */
     @Override
     public void doActivity() {
-        System.out.println("[INFO::FSM] Scheduler:ReceivingState:Do");
+
+        String msg = "";
 
         // Case: Event is ElevatorStateEvent
         // Description: Notification from Elevator conveying its state
         if (event instanceof ElevatorStateEvent esEvent) {
-            System.out.println("[INFO::FSM] Scheduler:ReceivingState:Entry: Received ElevatorStateEvent.");
+            msg = "Received ElevatorStateEvent.";
+            ((Scheduler)context).logger.log(Logging.Logger.LEVEL.DEBUG, ((Scheduler)context).logId, msg);
             // Next State: ProcessingElevatorEventState
             // Required Constructor Arguments: context
             context.setNextState(new ProcessingElevatorEventState(context, esEvent)); 
@@ -69,7 +72,8 @@ public class ReceivingState extends State {
         // Case: Event is FloorRequestEvent
         // Description: Request from Floor asking for service
         else if (event instanceof FloorRequestEvent frEvent) {
-            System.out.println("[INFO::FSM] Scheduler:ReceivingState:Entry: Received FloorRequestEvent.");
+            msg = "Received FloorRequestEvent.";
+            ((Scheduler)context).logger.log(Logging.Logger.LEVEL.DEBUG, ((Scheduler)context).logId, msg);
             // Next State: StoringFloorRequestState
             // Required Constructor Arguments: context
             context.setNextState(new StoringFloorRequestState(context, frEvent)); 
@@ -77,7 +81,8 @@ public class ReceivingState extends State {
         // Case: Event is PassengerLoadEvent
         // Description: Notification from Floor of Passengers requiring load
         else if (event instanceof PassengerLoadEvent plEvent) {
-            System.out.println("[INFO::FSM] Scheduler:ReceivingState:Entry: Received PassengerLoadEvent.");
+            msg = "Received PassengerLoadEvent.";
+            ((Scheduler)context).logger.log(Logging.Logger.LEVEL.DEBUG, ((Scheduler)context).logId, msg);
             // Next State: LoadingPassengerState
             // Required Constructor Arguments: PassengerLoadEvent
             context.setNextState(new LoadingPassengerState(context, plEvent));
@@ -85,7 +90,8 @@ public class ReceivingState extends State {
         // Case: Event is ReceiverBindingEvent
         // Description: Request to bind a Receiver to this Scheduler Subsystem
         else if (event instanceof ReceiverBindingEvent rbEvent) {
-            System.out.println("[INFO::FSM] Scheduler:ReceivingState:Entry: Received ReceiverBindingEvent.");
+            msg = "Received ReceiverBindingEvent.";
+            ((Scheduler)context).logger.log(Logging.Logger.LEVEL.DEBUG, ((Scheduler)context).logId, msg);
             // Next State: BindingReceiverState
             // Required Constructor Arguments: ReceiverBindingEvent
             context.setNextState(new BindingReceiverState(context, rbEvent));
@@ -102,7 +108,6 @@ public class ReceivingState extends State {
      */
     @Override
     public void exit() {
-        System.out.println("[INFO::FSM] Scheduler:ReceivingState:Exit");
     }
 
 }

--- a/src/Subsystem/SchedulerSubsystem/Scheduler.java
+++ b/src/Subsystem/SchedulerSubsystem/Scheduler.java
@@ -73,7 +73,7 @@ public class Scheduler extends Context implements Subsystem {
      */
     void storeFloorRequest(FloorRequestEvent event) {
         // Log
-        String msg = ("Floor " + event.destinationEvent().destinationFloor() + ": request made: " + event.destinationEvent().direction() + ".");
+        String msg = ("Floor " + event.destinationEvent().destinationFloor() + ": Request made: " + event.destinationEvent().direction() + ".");
         logger.log(Logger.LEVEL.INFO, logId, msg);
         // Store event locally to use in scheduling
         if (!floorRequestsToTime.containsKey(event.destinationEvent()))

--- a/src/Subsystem/SchedulerSubsystem/Scheduler.java
+++ b/src/Subsystem/SchedulerSubsystem/Scheduler.java
@@ -1,5 +1,7 @@
 package Subsystem.SchedulerSubsystem;
 
+import Configuration.Config;
+import Logging.Logger;
 import Messaging.Messages.Commands.SystemCommand;
 import Messaging.Messages.Direction;
 import Messaging.Messages.Events.DestinationEvent;
@@ -28,8 +30,11 @@ public class Scheduler extends Context implements Subsystem {
     private final Receiver receiver;
     private final Map<DestinationEvent, Long> floorRequestsToTime;
     private final ArrayList<ElevatorStateEvent> idleElevators;
+    final Logger logger;
+    final String logId = "SCHEDULER";
 
-    public Scheduler(Receiver receiver,
+    public Scheduler(Config config,
+                     Receiver receiver,
                      Transmitter<? extends Receiver> transmitterToFloor,
                      Transmitter<? extends Receiver> transmitterToElevator) {
         this.receiver = receiver;
@@ -37,6 +42,8 @@ public class Scheduler extends Context implements Subsystem {
         this.transmitterToFloor = transmitterToFloor;
         floorRequestsToTime = new HashMap<>();
         idleElevators = new ArrayList<>();
+        // Logging
+        logger = new Logger(config.getVerbosity());
 
         // Initialize first state for this Subsystem's State Machine
         setNextState(new ReceivingState(this));
@@ -65,7 +72,9 @@ public class Scheduler extends Context implements Subsystem {
      * @param event Event to process.
      */
     void storeFloorRequest(FloorRequestEvent event) {
-        System.out.println("Floor " + event.destinationEvent().destinationFloor() + ": request made: " + event.destinationEvent().direction() + ".");
+        // Log
+        String msg = ("Floor " + event.destinationEvent().destinationFloor() + ": request made: " + event.destinationEvent().direction() + ".");
+        logger.log(Logger.LEVEL.INFO, logId, msg);
         // Store event locally to use in scheduling
         if (!floorRequestsToTime.containsKey(event.destinationEvent()))
             // Only store request if it does not already exist

--- a/src/Subsystem/SchedulerSubsystem/StoringFloorRequestState.java
+++ b/src/Subsystem/SchedulerSubsystem/StoringFloorRequestState.java
@@ -45,7 +45,8 @@ public class StoringFloorRequestState extends State {
      */
     @Override
     public void entry() {
-        System.out.println("[INFO::FSM] Scheduler:StoringFloorRequestState:Entry");
+        String msg = "StoringFloorRequestState:Entry";
+        ((Scheduler)context).logger.log(Logging.Logger.LEVEL.DEBUG, ((Scheduler)context).logId, msg);
     }
 
     /**
@@ -56,7 +57,6 @@ public class StoringFloorRequestState extends State {
      */
     @Override
     public void doActivity() {
-        System.out.println("[INFO::FSM] Scheduler:StoringFloorRequestState:Do");
 
         // Store the FloorRequestEvent
         ((Scheduler)context).storeFloorRequest(event);
@@ -84,7 +84,6 @@ public class StoringFloorRequestState extends State {
      */
     @Override
     public void exit() {
-        System.out.println("[INFO::FSM] Scheduler:StoringFloorRequestState:Exit");
     }
 
 }

--- a/test/unit/Logging/LoggerTest.java
+++ b/test/unit/Logging/LoggerTest.java
@@ -1,0 +1,82 @@
+/**
+ * Test class for Logger class.
+ *
+ * Since this class only tests system prints, requires visual inspection of
+ * output.
+ *
+ * @author Michael De Santis
+ * @version Iteration-3
+ */
+package unit.Logging;
+
+import Logging.Logger;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LoggerTest {
+
+    private final String logId = "LoggerTest";
+
+    @org.junit.jupiter.api.BeforeEach
+    void setUp() {
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    void testLog() {
+
+        System.out.println("\n****** START: testLog() ******");
+
+        // System verbosity
+        int verbosity;
+
+        // Message storage
+        String message;
+
+        // Message level storage
+        Logger.LEVEL level;
+
+        /* Test verbosity == 0 */
+        // Expect nothing (ie. no prints)
+        System.out.println("\n*** Test: verbosity == 0 ***");
+        System.out.println("Expect no messages to print below this one.");
+        verbosity = 0;
+        Logger silentLogger = new Logger(verbosity);
+        level = Logger.LEVEL.DEBUG;
+        message = "testing silent mode";
+        silentLogger.log(level, logId, message);
+
+        /* Test verbosity == 1 */
+        // Expect only INFO level messages to print
+        System.out.println("\n*** Test: verbosity == 1 ***");
+        System.out.println("Expect only INFO level messages to print below this one.");
+        verbosity = 1;
+        Logger infoLogger = new Logger(verbosity);
+        level = Logger.LEVEL.DEBUG;
+        message = "verbosity==1: testing DEBUG message";
+        infoLogger.log(level, logId, message);
+        level = Logger.LEVEL.INFO;
+        message = "verbosity==1: testing INFO message";
+        infoLogger.log(level, logId, message);
+
+        /* Test verbosity == 2 */
+        // Expect both INFO and DEBUG level messages to print
+        System.out.println("\n*** Test: verbosity == 2 ***");
+        System.out.println("Expect both INFO and DEBUG level messages to print below this one.");
+        verbosity = 2;
+        Logger debugLogger = new Logger(verbosity);
+        level = Logger.LEVEL.DEBUG;
+        message = "verbosity==2: testing DEBUG message";
+        debugLogger.log(level, logId, message);
+        level = Logger.LEVEL.INFO;
+        message = "verbosity==2: testing INFO message";
+        debugLogger.log(level, logId, message);
+
+        System.out.println("\n****** END: testLog() ******");
+    }
+
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] ✅ Test
- [ ] 🧑‍💻 Refactor

## Description
Implemented a logger (well, really just a printer) to make prints a bit more uniform.
* Logger added in the Subsystem/Logging subsystem.
* Added a config parameter in JSON to set verbosity (1 for info, 2 for debug) to make it easy to change.
* Added config parameters for some class constructors so that they could all get the same verbosity level from the config JSON.
* Cleaned up all prints to use Logger to print instead.
* Made decisions on what was info/debug - if anyone wants to change a print from one to the other, go for it - don't ask me first!
* Quick test file just to verify my own work for the logging levels.
* Cleaned up a few other random prints and style fluff here and there.
* Tested both verbosity levels on both the UDP and DMA implementations - both behaved the same and as expected.
* Hopefully this looks a little cleaner!

## How to test
1. Set your verbosity level in the JSON (1 for INFO only, 2 for INFO/DEBUG)
2. Run the DMA code, look at the prints.
3. Run the UDP code, look at the prints.

## Notes
* Will add brief documentation notes to README in separate PR.

## Added/updated tests?

- [X] Yes:  a kinda fake test, just my working test file for the verbosity logic so I could visually inspect the prints.
- [ ] No, and this is why:
- [ ] I need help with writing tests:.

## Screenshots
