### PR TITLE
Adding Fault types to passenger data.

### DIFF
--- a/src/Messaging/Messages/Events/DestinationEvent.java
+++ b/src/Messaging/Messages/Events/DestinationEvent.java
@@ -15,4 +15,30 @@ import Messaging.Messages.Fault;
  */
 public record DestinationEvent
         (int destinationFloor, Direction direction, Fault faultType)
-        implements SystemEvent {}
+        implements SystemEvent {
+
+    /**
+     * Override default equals method to accept a null faultType as a wildcard match against other faults
+     *
+     * @param o the reference object with which to compare.
+     * @return True if all fields match,
+     * or all fields except fault match and one of the two objects has a null (wildcard) fault.
+     */
+    @Override
+    public boolean equals(Object o) {
+        // Check identical
+        if (this == o)
+            return true;
+        // Type cast o to this type
+        if (!(o instanceof DestinationEvent de))
+            return false;
+        // Check normal fields (no wildcards)
+        if (de.destinationFloor != this.destinationFloor || de.direction != this.direction)
+            return false;
+        // Wildcard fault type exists (no need to check it)
+        if (de.faultType == null || this.faultType == null)
+            return true;
+        // Check fault type
+        return de.faultType == this.faultType;
+    }
+}

--- a/src/Messaging/Messages/Events/DestinationEvent.java
+++ b/src/Messaging/Messages/Events/DestinationEvent.java
@@ -1,8 +1,7 @@
 package Messaging.Messages.Events;
 
 import Messaging.Messages.Direction;
-
-import java.io.Serializable;
+import Messaging.Messages.Fault;
 
 /**
  * DestinationEvent record, holds data modelling a destination.
@@ -15,5 +14,5 @@ import java.io.Serializable;
  * @author Alexandre Marques
  */
 public record DestinationEvent
-        (int destinationFloor, Direction direction)
+        (int destinationFloor, Direction direction, Fault faultType)
         implements SystemEvent {}

--- a/src/Messaging/Messages/Events/FloorInputEvent.java
+++ b/src/Messaging/Messages/Events/FloorInputEvent.java
@@ -1,8 +1,7 @@
 package Messaging.Messages.Events;
 
 import Messaging.Messages.Direction;
-
-import java.io.Serializable;
+import Messaging.Messages.Fault;
 
 /**
  * FloorInputEvent record, models an input event to the system. These events
@@ -18,5 +17,5 @@ import java.io.Serializable;
  * @version Iteration-2
  */
 public record FloorInputEvent
-        (long time, int sourceFloor, Direction direction, int destinationFloor)
+        (long time, int sourceFloor, Direction direction, int destinationFloor, Fault faultType)
         implements SystemEvent {}

--- a/src/Messaging/Messages/Fault.java
+++ b/src/Messaging/Messages/Fault.java
@@ -1,0 +1,12 @@
+package Messaging.Messages;
+
+/**
+ * Enum for fault types.
+ *
+ * @version iteration-4
+ */
+public enum Fault {
+    NONE,
+    TRANSIENT,
+    HARD
+}

--- a/src/Subsystem/ElevatorSubsytem/Elevator.java
+++ b/src/Subsystem/ElevatorSubsytem/Elevator.java
@@ -2,7 +2,6 @@ package Subsystem.ElevatorSubsytem;
 
 import Configuration.Config;
 import Logging.Logger;
-import Configuration.Configurator;
 import Messaging.Messages.Commands.MovePassengersCommand;
 import Messaging.Messages.Direction;
 import Messaging.Messages.Events.DestinationEvent;
@@ -86,10 +85,10 @@ public class Elevator extends Context implements Subsystem {
         }
         try {
             // Log
-            String msg = "Unloading Passenger: " + passengerCountMap.get(new DestinationEvent(currentFloor, direction));
+            String msg = "Unloading Passenger: " + passengerCountMap.get(new DestinationEvent(currentFloor, direction, null));
             logger.log(Logger.LEVEL.INFO, logId, msg);
             // each passenger takes loadTime to leave the elevator.
-            Thread.sleep(loadTime * passengerCountMap.remove(new DestinationEvent(currentFloor,direction)));
+            Thread.sleep(loadTime * passengerCountMap.remove(new DestinationEvent(currentFloor, direction, null)));
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         } catch (NullPointerException e) {

--- a/src/Subsystem/FloorSubsystem/Parser.java
+++ b/src/Subsystem/FloorSubsystem/Parser.java
@@ -152,7 +152,8 @@ public class Parser {
         int destinationFloor = Integer.parseInt(splits[3]);
 
         // Create and return FloorInputEvent record with the above values as fields
-        floorInputEvent = new FloorInputEvent(arrivalTime, sourceFloor, direction, destinationFloor);
+        // TODO: Modify null value with a real fault!!
+        floorInputEvent = new FloorInputEvent(arrivalTime, sourceFloor, direction, destinationFloor, null);
 
         return floorInputEvent;
     }

--- a/src/Subsystem/SchedulerSubsystem/ProcessingElevatorEventState.java
+++ b/src/Subsystem/SchedulerSubsystem/ProcessingElevatorEventState.java
@@ -1,14 +1,11 @@
 package Subsystem.SchedulerSubsystem;
 
 import Messaging.Messages.Commands.MoveElevatorCommand;
+import Messaging.Messages.Commands.SendPassengersCommand;
 import Messaging.Messages.Events.DestinationEvent;
 import Messaging.Messages.Events.ElevatorStateEvent;
-import Messaging.Messages.Events.PassengerLoadEvent;
-import Messaging.Messages.SystemMessage;
-import Messaging.Messages.Commands.SendPassengersCommand;
 import StatePatternLib.Context;
 import StatePatternLib.State;
-import com.sun.jdi.InvalidTypeException;
 
 /**
  * Scheduler FSM State: Processing Elevator Event State.
@@ -28,7 +25,7 @@ public class ProcessingElevatorEventState extends State {
     /* Instance Variables */
     
     // The ElevatorStentEvent to process
-    private ElevatorStateEvent event;
+    private final ElevatorStateEvent event;
 
     /**
      * Parametric constructor.
@@ -85,7 +82,7 @@ public class ProcessingElevatorEventState extends State {
             ((Scheduler)context).transmitToFloor(new SendPassengersCommand(event.currentFloor(), event.elevatorNum(), ((Scheduler)context).getElevatorDirection(event)));
 
             // Remove the serviced DestinationRequest request
-            ((Scheduler)context).removeDestinationEvent(new DestinationEvent(event.currentFloor(),((Scheduler)context).getElevatorDirection(event)));
+            ((Scheduler) context).removeDestinationEvent(new DestinationEvent(event.currentFloor(), ((Scheduler) context).getElevatorDirection(event), null));
 
             // Next State: ReceivingState
             // Required Constructor Arguments: context

--- a/src/Subsystem/SchedulerSubsystem/Scheduler.java
+++ b/src/Subsystem/SchedulerSubsystem/Scheduler.java
@@ -140,7 +140,7 @@ public class Scheduler extends Context implements Subsystem {
         // Convenience variable to extract and hold target floor
         int targetFloor = floorRequestEvent.destinationEvent().destinationFloor();
         // Distance tracker (in number of floors)
-        int distance = 0;
+        int distance;
         // Initialize variables for our sort algorithm using the first idle elevator
         int closestIdleElevatorIndex = 0;
         int closestDistance = abs(idleElevators.get(0).currentFloor()- targetFloor);
@@ -191,7 +191,8 @@ public class Scheduler extends Context implements Subsystem {
         if (isMovingOppositeToFutureDirection(e)) {
             return false;
         }
-        return union.contains(new DestinationEvent(e.currentFloor(), getElevatorDirection(e)));
+        // Fault: Assume NONE,
+        return union.contains(new DestinationEvent(e.currentFloor(), getElevatorDirection(e), null));
     }
 
     /**

--- a/test/integration/TransceiverDMATest.java
+++ b/test/integration/TransceiverDMATest.java
@@ -27,7 +27,7 @@ public class TransceiverDMATest {
 
         System.out.println("Create an ElevatorStateEvent SystemMessage");
         HashMap<DestinationEvent, Integer> passengerCountMap = new HashMap<>();
-        DestinationEvent e = new DestinationEvent(3, Direction.DOWN);
+        DestinationEvent e = new DestinationEvent(3, Direction.DOWN, null);
         passengerCountMap.put(e, 5);
         ElevatorStateEvent elevatorStateEvent = new ElevatorStateEvent(5, 7, passengerCountMap);
 

--- a/test/integration/TransceiverUDPMultiReceiversTest.java
+++ b/test/integration/TransceiverUDPMultiReceiversTest.java
@@ -40,7 +40,7 @@ public class TransceiverUDPMultiReceiversTest {
 
         // Initializing ElevatorStateEvent for the scheduler to send to the floors
         HashMap<DestinationEvent, Integer> passengerCountMap = new HashMap<>();
-        DestinationEvent e = new DestinationEvent(3, Direction.DOWN);
+        DestinationEvent e = new DestinationEvent(3, Direction.DOWN, null);
         passengerCountMap.put(e, 5);
         ElevatorStateEvent elevatorStateEvent = new ElevatorStateEvent(5, 7, passengerCountMap);
 

--- a/test/integration/TransceiverUDPTest.java
+++ b/test/integration/TransceiverUDPTest.java
@@ -24,7 +24,7 @@ public class TransceiverUDPTest {
         udp_transmitter.addReceiver(udp_receiver.getSerializableReceiver());
 
         System.out.println("Create a DestinationEvent SystemMessage.");
-        DestinationEvent destEvent = new DestinationEvent(2, Direction.UP);
+        DestinationEvent destEvent = new DestinationEvent(2, Direction.UP, null);
         udp_transmitter.send(destEvent);
 
         System.out.println("Call dequeueMessage on the ReceiverUDP to read the SystemMessage.");

--- a/test/unit/ElevatorSybsystem/ElevatorUtilitiesTest.java
+++ b/test/unit/ElevatorSybsystem/ElevatorUtilitiesTest.java
@@ -34,8 +34,8 @@ class ElevatorUtilitiesTest {
      */
     @Test
     void passengersGoingUp() {
-        DestinationEvent dest1 = new DestinationEvent(3, Direction.UP);
-        DestinationEvent dest2 = new DestinationEvent(5, Direction.UP);
+        DestinationEvent dest1 = new DestinationEvent(3, Direction.UP, null);
+        DestinationEvent dest2 = new DestinationEvent(5, Direction.UP, null);
 
         passengers.add(dest1);
         passengers.add(dest2);
@@ -49,8 +49,8 @@ class ElevatorUtilitiesTest {
      */
     @Test
     void passengersGoingDown() {
-        DestinationEvent dest1 = new DestinationEvent(1, Direction.DOWN);
-        DestinationEvent dest2 = new DestinationEvent(2, Direction.DOWN);
+        DestinationEvent dest1 = new DestinationEvent(1, Direction.DOWN, null);
+        DestinationEvent dest2 = new DestinationEvent(2, Direction.DOWN, null);
 
         passengers.add(dest1);
         passengers.add(dest2);
@@ -64,8 +64,8 @@ class ElevatorUtilitiesTest {
      */
     @Test
     void passengersGoingDifferentDirections() {
-        DestinationEvent dest1 = new DestinationEvent(5, Direction.UP);
-        DestinationEvent dest2 = new DestinationEvent(3, Direction.DOWN);
+        DestinationEvent dest1 = new DestinationEvent(5, Direction.UP, null);
+        DestinationEvent dest2 = new DestinationEvent(3, Direction.DOWN, null);
 
         passengers.add(dest1);
         passengers.add(dest2);

--- a/test/unit/FloorSubsystem/ParserTest.java
+++ b/test/unit/FloorSubsystem/ParserTest.java
@@ -24,7 +24,7 @@ class ParserTest {
     @org.junit.jupiter.api.BeforeEach
     void setUp() {
         parser = new Parser();
-        floorInputEvents = new ArrayList<FloorInputEvent>();
+        floorInputEvents = new ArrayList<>();
     }
 
     @org.junit.jupiter.api.AfterEach
@@ -45,140 +45,140 @@ class ParserTest {
         /* Check each instantiated FloorInputEvent member against expected value */
 
         //FloorInputEvent: 0
-        FloorInputEvent a0 = new FloorInputEvent(32722123, 1, Direction.UP, 7);
+        FloorInputEvent a0 = new FloorInputEvent(32722123, 1, Direction.UP, 7, null);
         assertEquals(a0.time(), floorInputEvents.get(0).time());
         assertEquals(a0.sourceFloor(), floorInputEvents.get(0).sourceFloor());
         assertEquals(a0.direction(), floorInputEvents.get(0).direction());
         assertEquals(a0.destinationFloor(), floorInputEvents.get(0).destinationFloor());
 
         // FloorInputEvent: 1
-        FloorInputEvent a1= new FloorInputEvent(32732994, 1, Direction.UP, 3);
+        FloorInputEvent a1 = new FloorInputEvent(32732994, 1, Direction.UP, 3, null);
         assertEquals(a1.time(), floorInputEvents.get(1).time());
         assertEquals(a1.sourceFloor(), floorInputEvents.get(1).sourceFloor());
         assertEquals(a1.direction(), floorInputEvents.get(1).direction());
         assertEquals(a1.destinationFloor(), floorInputEvents.get(1).destinationFloor());
 
         // FloorInputEvent: 2
-        FloorInputEvent a2= new FloorInputEvent(32735061, 1, Direction.UP, 6);
+        FloorInputEvent a2 = new FloorInputEvent(32735061, 1, Direction.UP, 6, null);
         assertEquals(a2.time(), floorInputEvents.get(2).time());
         assertEquals(a2.sourceFloor(), floorInputEvents.get(2).sourceFloor());
         assertEquals(a2.direction(), floorInputEvents.get(2).direction());
         assertEquals(a2.destinationFloor(), floorInputEvents.get(2).destinationFloor());
 
         // FloorInputEvent: 3
-        FloorInputEvent a3= new FloorInputEvent(32752485, 7, Direction.DOWN, 4);
+        FloorInputEvent a3 = new FloorInputEvent(32752485, 7, Direction.DOWN, 4, null);
         assertEquals(a3.time(), floorInputEvents.get(3).time());
         assertEquals(a3.sourceFloor(), floorInputEvents.get(3).sourceFloor());
         assertEquals(a3.direction(), floorInputEvents.get(3).direction());
         assertEquals(a3.destinationFloor(), floorInputEvents.get(3).destinationFloor());
 
         // FloorInputEvent: 4
-        FloorInputEvent a4= new FloorInputEvent(32763669, 2, Direction.UP, 5);
+        FloorInputEvent a4 = new FloorInputEvent(32763669, 2, Direction.UP, 5, null);
         assertEquals(a4.time(), floorInputEvents.get(4).time());
         assertEquals(a4.sourceFloor(), floorInputEvents.get(4).sourceFloor());
         assertEquals(a4.direction(), floorInputEvents.get(4).direction());
         assertEquals(a4.destinationFloor(), floorInputEvents.get(4).destinationFloor());
 
         // FloorInputEvent: 5
-        FloorInputEvent a5= new FloorInputEvent(32774334, 5, Direction.DOWN, 2);
+        FloorInputEvent a5 = new FloorInputEvent(32774334, 5, Direction.DOWN, 2, null);
         assertEquals(a5.time(), floorInputEvents.get(5).time());
         assertEquals(a5.sourceFloor(), floorInputEvents.get(5).sourceFloor());
         assertEquals(a5.direction(), floorInputEvents.get(5).direction());
         assertEquals(a5.destinationFloor(), floorInputEvents.get(5).destinationFloor());
 
         // FloorInputEvent: 6
-        FloorInputEvent a6= new FloorInputEvent(32776301, 5, Direction.DOWN, 1);
+        FloorInputEvent a6 = new FloorInputEvent(32776301, 5, Direction.DOWN, 1, null);
         assertEquals(a6.time(), floorInputEvents.get(6).time());
         assertEquals(a6.sourceFloor(), floorInputEvents.get(6).sourceFloor());
         assertEquals(a6.direction(), floorInputEvents.get(6).direction());
         assertEquals(a6.destinationFloor(), floorInputEvents.get(6).destinationFloor());
 
         // FloorInputEvent: 7
-        FloorInputEvent a7= new FloorInputEvent(32779449, 4, Direction.DOWN, 1);
+        FloorInputEvent a7 = new FloorInputEvent(32779449, 4, Direction.DOWN, 1, null);
         assertEquals(a7.time(), floorInputEvents.get(7).time());
         assertEquals(a7.sourceFloor(), floorInputEvents.get(7).sourceFloor());
         assertEquals(a7.direction(), floorInputEvents.get(7).direction());
         assertEquals(a7.destinationFloor(), floorInputEvents.get(7).destinationFloor());
 
         // FloorInputEvent: 8
-        FloorInputEvent a8= new FloorInputEvent(32787678, 2, Direction.UP, 7);
+        FloorInputEvent a8 = new FloorInputEvent(32787678, 2, Direction.UP, 7, null);
         assertEquals(a8.time(), floorInputEvents.get(8).time());
         assertEquals(a8.sourceFloor(), floorInputEvents.get(8).sourceFloor());
         assertEquals(a8.direction(), floorInputEvents.get(8).direction());
         assertEquals(a8.destinationFloor(), floorInputEvents.get(8).destinationFloor());
 
         // FloorInputEvent: 9
-        FloorInputEvent a9= new FloorInputEvent(32793994, 3, Direction.DOWN, 1);
+        FloorInputEvent a9 = new FloorInputEvent(32793994, 3, Direction.DOWN, 1, null);
         assertEquals(a9.time(), floorInputEvents.get(9).time());
         assertEquals(a9.sourceFloor(), floorInputEvents.get(9).sourceFloor());
         assertEquals(a9.direction(), floorInputEvents.get(9).direction());
         assertEquals(a9.destinationFloor(), floorInputEvents.get(9).destinationFloor());
 
         // FloorInputEvent: 10
-        FloorInputEvent a10= new FloorInputEvent(32798165, 1, Direction.UP, 2);
+        FloorInputEvent a10 = new FloorInputEvent(32798165, 1, Direction.UP, 2, null);
         assertEquals(a10.time(), floorInputEvents.get(10).time());
         assertEquals(a10.sourceFloor(), floorInputEvents.get(10).sourceFloor());
         assertEquals(a10.direction(), floorInputEvents.get(10).direction());
         assertEquals(a10.destinationFloor(), floorInputEvents.get(10).destinationFloor());
 
         // FloorInputEvent: 11
-        FloorInputEvent a11= new FloorInputEvent(32810778, 1, Direction.UP, 7);
+        FloorInputEvent a11 = new FloorInputEvent(32810778, 1, Direction.UP, 7, null);
         assertEquals(a11.time(), floorInputEvents.get(11).time());
         assertEquals(a11.sourceFloor(), floorInputEvents.get(11).sourceFloor());
         assertEquals(a11.direction(), floorInputEvents.get(11).direction());
         assertEquals(a11.destinationFloor(), floorInputEvents.get(11).destinationFloor());
 
         // FloorInputEvent: 12
-        FloorInputEvent a12= new FloorInputEvent(32812393, 7, Direction.DOWN, 1);
+        FloorInputEvent a12 = new FloorInputEvent(32812393, 7, Direction.DOWN, 1, null);
         assertEquals(a12.time(), floorInputEvents.get(12).time());
         assertEquals(a12.sourceFloor(), floorInputEvents.get(12).sourceFloor());
         assertEquals(a12.direction(), floorInputEvents.get(12).direction());
         assertEquals(a12.destinationFloor(), floorInputEvents.get(12).destinationFloor());
 
         // FloorInputEvent: 13
-        FloorInputEvent a13= new FloorInputEvent(32814651, 7, Direction.DOWN, 2);
+        FloorInputEvent a13 = new FloorInputEvent(32814651, 7, Direction.DOWN, 2, null);
         assertEquals(a13.time(), floorInputEvents.get(13).time());
         assertEquals(a13.sourceFloor(), floorInputEvents.get(13).sourceFloor());
         assertEquals(a13.direction(), floorInputEvents.get(13).direction());
         assertEquals(a13.destinationFloor(), floorInputEvents.get(13).destinationFloor());
 
         // FloorInputEvent: 14
-        FloorInputEvent a14= new FloorInputEvent(32819912, 4, Direction.DOWN, 1);
+        FloorInputEvent a14 = new FloorInputEvent(32819912, 4, Direction.DOWN, 1, null);
         assertEquals(a14.time(), floorInputEvents.get(14).time());
         assertEquals(a14.sourceFloor(), floorInputEvents.get(14).sourceFloor());
         assertEquals(a14.direction(), floorInputEvents.get(14).direction());
         assertEquals(a14.destinationFloor(), floorInputEvents.get(14).destinationFloor());
 
         // FloorInputEvent: 15
-        FloorInputEvent a15= new FloorInputEvent(32828870, 5, Direction.UP, 6);
+        FloorInputEvent a15 = new FloorInputEvent(32828870, 5, Direction.UP, 6, null);
         assertEquals(a15.time(), floorInputEvents.get(15).time());
         assertEquals(a15.sourceFloor(), floorInputEvents.get(15).sourceFloor());
         assertEquals(a15.direction(), floorInputEvents.get(15).direction());
         assertEquals(a15.destinationFloor(), floorInputEvents.get(15).destinationFloor());
 
         // FloorInputEvent: 16
-        FloorInputEvent a16= new FloorInputEvent(32829113, 4, Direction.UP, 6);
+        FloorInputEvent a16 = new FloorInputEvent(32829113, 4, Direction.UP, 6, null);
         assertEquals(a16.time(), floorInputEvents.get(16).time());
         assertEquals(a16.sourceFloor(), floorInputEvents.get(16).sourceFloor());
         assertEquals(a16.direction(), floorInputEvents.get(16).direction());
         assertEquals(a16.destinationFloor(), floorInputEvents.get(16).destinationFloor());
 
         // FloorInputEvent: 17
-        FloorInputEvent a17= new FloorInputEvent(32841833, 7, Direction.DOWN, 1);
+        FloorInputEvent a17 = new FloorInputEvent(32841833, 7, Direction.DOWN, 1, null);
         assertEquals(a17.time(), floorInputEvents.get(17).time());
         assertEquals(a17.sourceFloor(), floorInputEvents.get(17).sourceFloor());
         assertEquals(a17.direction(), floorInputEvents.get(17).direction());
         assertEquals(a17.destinationFloor(), floorInputEvents.get(17).destinationFloor());
 
         // FloorInputEvent: 18
-        FloorInputEvent a18= new FloorInputEvent(32844113, 7, Direction.DOWN, 4);
+        FloorInputEvent a18 = new FloorInputEvent(32844113, 7, Direction.DOWN, 4, null);
         assertEquals(a18.time(), floorInputEvents.get(18).time());
         assertEquals(a18.sourceFloor(), floorInputEvents.get(18).sourceFloor());
         assertEquals(a18.direction(), floorInputEvents.get(18).direction());
         assertEquals(a18.destinationFloor(), floorInputEvents.get(18).destinationFloor());
 
         // FloorInputEvent: 19
-        FloorInputEvent a19= new FloorInputEvent(32851113, 2, Direction.DOWN, 1);
+        FloorInputEvent a19 = new FloorInputEvent(32851113, 2, Direction.DOWN, 1, null);
         assertEquals(a19.time(), floorInputEvents.get(19).time());
         assertEquals(a19.sourceFloor(), floorInputEvents.get(19).sourceFloor());
         assertEquals(a19.direction(), floorInputEvents.get(19).direction());

--- a/test/unit/Networking/DestinationEventTest.java
+++ b/test/unit/Networking/DestinationEventTest.java
@@ -1,0 +1,36 @@
+package unit.Networking;
+
+import Messaging.Messages.Direction;
+import Messaging.Messages.Events.DestinationEvent;
+import Messaging.Messages.Fault;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class DestinationEventTest {
+    @Test
+    void testEqualsNormalFields() {
+        DestinationEvent deIni = new DestinationEvent(1, Direction.UP, null);
+        DestinationEvent deSame = new DestinationEvent(1, Direction.UP, null);
+        DestinationEvent deDiffDir = new DestinationEvent(1, Direction.DOWN, null);
+        DestinationEvent deDiffFloor = new DestinationEvent(2, Direction.UP, null);
+
+        assertEquals(deIni, deIni); // Same object
+        assertEquals(deIni, deSame); // Diff object, same fields
+        assertNotEquals(deIni, deDiffDir); // Different direction field
+        assertNotEquals(deIni, deDiffFloor); // Different floor field
+
+    }
+
+    @Test
+    void testEqualsFault() {
+        DestinationEvent deIni = new DestinationEvent(1, Direction.UP, Fault.NONE);
+        DestinationEvent deWildFault = new DestinationEvent(1, Direction.UP, null);
+        DestinationEvent deDiffFault = new DestinationEvent(1, Direction.UP, Fault.HARD);
+
+        assertEquals(deIni, deWildFault); // Null fault acts as wildcard
+        assertNotEquals(deIni, deDiffFault); // Different concrete fault should not be equal
+    }
+
+}

--- a/test/unit/Networking/ReceiverDMATest.java
+++ b/test/unit/Networking/ReceiverDMATest.java
@@ -10,7 +10,7 @@ import Messaging.Transceivers.Receivers.ReceiverDMA;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ReceiverDMATest {
 
@@ -22,7 +22,7 @@ class ReceiverDMATest {
     @Test
     void setReceiveEvent() {
         // Verify single set/receive scenario works
-        SystemEvent sndEvent = new DestinationEvent(2, Direction.UP);
+        SystemEvent sndEvent = new DestinationEvent(2, Direction.UP, null);
         receiver.receiveDMA(sndEvent);
 
         SystemMessage receivedEvent = receiver.dequeueMessage();
@@ -32,11 +32,11 @@ class ReceiverDMATest {
     @Test
     void setReceiveEventFIFO() {
         // Verify receiver Queue behavior (FIFO)
-        SystemEvent sndEvent = new DestinationEvent(1, Direction.UP);
+        SystemEvent sndEvent = new DestinationEvent(1, Direction.UP, null);
         receiver.receiveDMA(sndEvent);
-        SystemEvent sndEvent2 = new DestinationEvent(2, Direction.UP);
+        SystemEvent sndEvent2 = new DestinationEvent(2, Direction.UP, null);
         receiver.receiveDMA(sndEvent2);
-        SystemEvent sndEvent3 = new DestinationEvent(3, Direction.UP);
+        SystemEvent sndEvent3 = new DestinationEvent(3, Direction.UP, null);
         receiver.receiveDMA(sndEvent3);
 
         assertEquals(receiver.dequeueMessage(), sndEvent);

--- a/test/unit/Networking/TransmitterDMATest.java
+++ b/test/unit/Networking/TransmitterDMATest.java
@@ -8,7 +8,7 @@ import Messaging.Transceivers.Transmitters.TransmitterDMA;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class TransmitterDMATest {
 
@@ -25,7 +25,7 @@ class TransmitterDMATest {
 
     @Test
     void send() {
-        systemEvent = new DestinationEvent(2, Direction.UP);
+        systemEvent = new DestinationEvent(2, Direction.UP, null);
         transmitter.send(systemEvent);
         DestinationEvent event = (DestinationEvent) receiver.dequeueMessage();
         assertEquals(2, event.destinationFloor());


### PR DESCRIPTION
- Passengers being DestinationEvent. Also includes "Floor requests" but their faults can be simply ignored if desired.
- Added to FloorInputEvent as well (since the inputs will have faults added to them)
- Adding fault packaging to dispatcher.

## What type of PR is this? (check all applicable)

- [X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] ✅ Test
- [X] 🧑‍💻 Refactor

## Description
- Adding support for faults in data structures
- Customized record equals method to implement a "wildcard" match with faults to allow for legacy processing parity.
- Added tests (see sections below)

## How to test
- Equals method has a new DestinationEventTest class in Networking unit tests.
- Run CombinedDMA to check for legacy parity (should be the same as before for now).

## Added/updated tests?

- [X] Yes: Added test for equals method created, modified tests to update to correct constructor for DestinationEvent
- [ ] No, and this is why: 
- [ ] I need help with writing tests:.

## Screenshots