### PR TITLE
Hard fault handling in Elevator move() method

### DIFF
--- a/src/Subsystem/ElevatorSubsytem/Elevator.java
+++ b/src/Subsystem/ElevatorSubsytem/Elevator.java
@@ -67,10 +67,26 @@ public class Elevator extends Context implements Subsystem {
         String msg = "Going " + direction + " from Floor " + this.currentFloor + ".";
         logger.log(Logger.LEVEL.INFO, logId, msg);
 
+        // If a passenger has a hard fault, send an interrupt to terminate current thread.
+        for (DestinationEvent e: passengerCountMap.keySet()) {
+            if (e.faultType() == Fault.HARD) {
+                msg = "Elevator " + elevNum + " is malfunctioning. Calling Carleton's elevator support contractor.";
+                logger.log(Logger.LEVEL.INFO, logId, msg);
+                Thread.currentThread().interrupt();
+            }
+        }
+
         try {
             Thread.sleep(this.travelTime);
         } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+            // Interrupt flag was set, joining thread for graceful termination.
+            msg = "Elevator " + elevNum + " is OUT OF SERVICE... forever.";
+            logger.log(Logger.LEVEL.INFO, logId, msg);
+            try {
+                Thread.currentThread().join();
+            } catch (InterruptedException ex) {
+                throw new RuntimeException(e);
+            }
         }
 
         currentFloor += direction.getDisplacement();


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] ✅ Test
- [ ] 🧑‍💻 Refactor

## Description
When an elevator begins moving, if a passenger with a hard fault is detected the thread is interrupted.
While the elevator attempts to "travel" the InterruptedException will be caught and handled by joining the thread.

Note: I'm still worried about the "missing passengers" but I believe it was mentioned that they will be handled once elevator support people arrive. (Therefore, not our problem)

## How to test
Scenario 4 or 6

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: Because Michael is a legend... (and already created test cases)
- [ ] I need help with writing tests:.

## Screenshots
![Screen Shot 2024-03-27 at 12 34 36 AM](https://github.com/ArthurAtangana/SYSC3303A_Project/assets/84146479/1d675fdd-082a-403f-8355-e20438ce3734)
