### PR TITLE
Iteration 5: DisplayConsole

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ Note: Compiled using JDK - 21 Oracle OpenJDK version 21.0.1
    1. Right click lib folder in root directory
    2. Select add as library
    3. Leave settings as default, select ok
-3. Run the files in the "Mains" package in this order:
+3. Initiate system-wide monitoring display console:
+   1. Run process for `src/Subsystem/Logging/DisplayConsole`
+4. Run the files in the "Mains" package in this order:
    1. MainSchedulerUDP
    2. MainElevatorUDP
    3. MainFloorUDP
@@ -88,7 +90,8 @@ See test README for test file structure.
 | SystemMessage           | Messaging              | Interface definition for all messages passed in the system to inherit.                        |
 | Loader                  | SchedulerSubsystem     | Loads appropriate passengers into an elevator.                                                |
 | Scheduler               | SchedulerSubsystem     | Models a scheduler in the simulation.                                                         |
-| Logger                  | Logging                | Provides logging services to subsystems with configurable verbosity                           |
+| Logger                  | Logging                | Provides logging services to subsystems with configurable verbosity.                          |
+| DisplayConsole          | Logging                | Centralizes subsystem logging to single console for system-wide monitoring.                   |
 | MainCombinedDMA         | Mains                  | Run all subsystems in a single process with shared memory communication.                      |
 | MainSchedulerUDP        | Mains                  | Run Scheduler subsystem in a dedicated process with networked communication via UDP.          |
 | MainElevatorUDP         | Mains                  | Run Elevator subsystem in a dedicated process with networked communication via UDP.           |
@@ -195,6 +198,17 @@ the highest throughput possible.If the design can lead to starvation, it is an i
 | Scenario Tests for Fault Handling       |Arthur Atangana  |
 | Parser Validation                       |Arthur Atangana  |
 | Fix: Elevator Bound Handling            |Arthur Atangana  |
+
+### Iteration 5
+
+|          Task                           | Assignee        |
+|-----------------------------------------|-----------------|
+| Display Console                         |Michael De Santis|
+|                                         |Braeden Kloke    |
+|                                         |Victoria Malouf  |
+|                                         |Alexandre Marques|
+|                                         |Arthur Atangana  |
+
 
 ## Test
 

--- a/src/Mains/MainCombinedDMA.java
+++ b/src/Mains/MainCombinedDMA.java
@@ -39,7 +39,7 @@ public class MainCombinedDMA {
 
         // Floor and elevator thread creation
         for (int i = 0; i < config.getNumFloors()+1; ++i) {
-            new Thread(new Floor(i, dmaFactory.createClientReceiver(i),
+            new Thread(new Floor(config, i, dmaFactory.createClientReceiver(i),
                     dmaFactory.createClientTransmitter())).start();
         }
         for (int i = 0; i < config.getNumElevators(); ++i) {

--- a/src/Mains/MainFloorUDP.java
+++ b/src/Mains/MainFloorUDP.java
@@ -26,7 +26,7 @@ public class MainFloorUDP {
 
         // 3. Create and start floors
         for (int i = 0; i < (config.getNumFloors()+1); ++i) {
-            Floor floor = new Floor(i, udpFactory.createClientReceiver(i), udpFactory.createClientTransmitter());
+            Floor floor = new Floor(config, i, udpFactory.createClientReceiver(i), udpFactory.createClientTransmitter());
             new Thread(floor).start();
         }
 

--- a/src/Subsystem/Logging/DisplayConsole.java
+++ b/src/Subsystem/Logging/DisplayConsole.java
@@ -32,6 +32,29 @@ public class DisplayConsole {
      * Default constructor for class Console. Set up a socket.
      */
     public DisplayConsole() {
+        String welcomeString = "************************************************************\n"
+                             + "**************** ELEVATOR SIMULATOR 3303 *******************\n"
+                             + "************************************************************\n"
+                             + "******* A real-cool, real-time elevator simulator. *********\n"
+                             + "************************************************************\n"
+                             + "*                                            |  |  |       *\n"
+                             + "* Authors: SYSC 3303A Group 1             ___|__|__|___    *\n"
+                             + "* ----------------------------           | ||       || |   *\n"
+                             + "* Arthur Atangana:   101005197           | ||   0   || |   *\n"
+                             + "* Victoria Malouf:   101179986           | || <`W'> || |   *\n"
+                             + "* Michael De Santis: 101213450           | ||   |   || |   *\n"
+                             + "* Braeden Kloke:     100895984           | ||  / \\  || |   *\n"
+                             + "* Alexandre Marques: 101189743           |_||_______||_|   *\n"
+                             + "*                                            |  |  |       *\n"
+                             + "* Thanks:                                    |  |  |       *\n"
+                             + "* ----------------------------               |  |  |       *\n"
+                             + "* TA Maede Davoudzade                        |  |  |       *\n"
+                             + "* Dr. Rami Sabouni                           |  |  |       *\n"
+                             + "*                                            |  |  |       *\n"
+                             + "************************************************************\n"
+                             + "* (づ｡◕‿‿◕｡)づ Ride safe!!                                  *\n"
+                             + "************************************************************\n";
+        System.out.println(welcomeString);
         try {
             // Rx from Logger
             rxSocket = new DatagramSocket(RX_PORT);

--- a/src/Subsystem/Logging/DisplayConsole.java
+++ b/src/Subsystem/Logging/DisplayConsole.java
@@ -1,0 +1,92 @@
+package Logging;
+
+import java.io.*;
+import java.net.*;
+
+/**
+ * Console class which receives Logging messages and centralizes display.
+ *
+ * @author M. Desantis
+ * @version Iteration-5
+ */
+public class DisplayConsole {
+    
+    /* Enums */
+    public enum LEVEL {
+        INFO,  // INFO level messages for general prints
+        DEBUG  // DEBUG level messages for additional debug prints
+    }
+
+    /* Constants */
+    public static final int RX_PORT = 55555;
+    public static final int MAX_MESSAGE_BYTES = 200;
+    public final String CONSOLE_LOG_ID = "CONSOLE";
+
+    /* Instance Variables */
+
+    private DatagramSocket rxSocket;
+
+    /* Constructors */
+
+    /**
+     * Default constructor for class Console. Set up a socket.
+     */
+    public DisplayConsole() {
+        try {
+            // Rx from Logger
+            rxSocket = new DatagramSocket(RX_PORT);
+            System.out.println(CONSOLE_LOG_ID + " established Rx Socket on: " + RX_PORT);
+        } catch (SocketException se) {
+            se.printStackTrace();
+            System.exit(1);
+        }
+    }
+
+    /* Methods */
+
+    /**
+     * Print a received Logging message to console.
+     */
+    public void listen() {
+
+        System.out.println(CONSOLE_LOG_ID + " listening on: " + RX_PORT);
+
+        // Loop forever
+        while (true) {
+
+            // Local vars
+            String msg;
+            int len;
+            byte[] data;
+            data = new byte[MAX_MESSAGE_BYTES];
+            // UDP packets and sockets
+            DatagramPacket rxPacket = new DatagramPacket(data, data.length);
+
+            // Block on RX socket until RX packet arrives from Client
+            try {
+                rxSocket.receive(rxPacket);
+            } catch (IOException e) {
+                e.printStackTrace();
+                System.exit(1);
+            }
+
+            // Convert data to string
+            len = rxPacket.getLength();
+            data = rxPacket.getData();
+            msg = new String(data, 0, len);
+
+            // Print the thing
+            System.out.println(msg);
+        }
+
+    }
+
+    /**
+     * Main method for this class.
+     */
+    public static void main(String[] args) {
+        Logging.DisplayConsole displayConsole = new Logging.DisplayConsole();
+        displayConsole.listen();
+    }
+
+}

--- a/test/resources/scenario-11-lamp-test.txt
+++ b/test/resources/scenario-11-lamp-test.txt
@@ -1,0 +1,31 @@
+###############################################################################
+# scenario-11-lamp-test.txt                                                   #
+###############################################################################
+# Input file used to provide inputs to the system. This file is assumed to be #
+# well-formed and is NOT validated at runtime.                                #
+###############################################################################
+# Scenario Description                                                        #
+# --------------------                                                        #
+# Simulate many button pushes on same floor to test UP/DOWN button lamp       #
+# handling.                                                                   #
+###############################################################################
+#  arrivalTime  | sourceFloor | direction | destinationFloor |   faultCode    #
+# --------------|-------------|-----------|------------------|----------------#
+#      int      |    int      | Direction |       int        |      int       #
+# --------------|-------------|-----------|------------------|----------------#
+#  hh:mm:ss.mmm |     n       | Up | Down |        n         |   0 | 1 | 2    #
+###############################################################################
+
+## Test Sequence ##
+
+# Floor 1: Impatient people keep hitting UP button even though already lit.
+09:05:32.123 3 Up 4 0
+09:05:33.994 3 Up 5 0
+09:05:35.001 3 Up 6 0
+09:05:37.061 3 Up 7 0
+
+# Floor 2: Impatient people keep hitting DOWN button even though already lit.
+09:06:12.123 3 Down 1 0
+09:06:13.994 3 Down 1 0
+09:06:15.001 3 Down 1 0
+09:06:17.061 3 Down 1 0


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] ✅ Test
- [ ] 🧑‍💻 Refactor

## Description
Adds a Single Pane of Glass (buzzword bonus?) display console to the system. This display console cooperates with each subsystem's logger, listening on a UDP socket,  and essentially just aggregates logged messages from each subsystem to a single console. If your subsystem logs it, this console should display it. 

I also added Logging capabilities to the silent Floor subsystem, just so we could see some messages print from there. 

Also added a few more prints to make things more elevatory (eg. we turn the UP/DOWN button lamps on off). 

Also added client-side timestamps (ie. subsystem queries clock before log) in UNIX epoch milliseconds.

Updated README with DisplayConsole info.


## How to test
Start the DisplayConsole first (or whenever you want to start monitoring), and then run the system as usual.

## Added/updated tests?

- [x] Yes: Just a quick scenario test to test button lamps. 
- [ ] No, and this is why: 
- [ ] I need help with writing tests:.

## Screenshots